### PR TITLE
feat: add skeleton loading state for event section

### DIFF
--- a/src/components/TrendingEvent.tsx
+++ b/src/components/TrendingEvent.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import TrendingCards from "./cards/TrendingCards";
+import DIvSkeleton from "./skeleton/DIvSkeleton";
 
 type Props = {};
 
 function TrendingEvent({}: Props) {
   return (
     <div className="h-auto w-full flex flex-col  bg-[#101428] lg:px-4 py-8 lg:py-12 items-center ">
+      
       <div className="flex flex-col items-center mt-8 lg:mt-12   w-full">
         <div className="items-start max-w-[1400px]  px-4 mb-10 flex-col gap-4 lg:gap-0  lg:flex-row flex w-full">
           <div className="w-full ">

--- a/src/components/skeleton/DIvSkeleton.jsx
+++ b/src/components/skeleton/DIvSkeleton.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function DIvSkeleton() {
+  return (
+    <div className="relative w-full h-60 mb-4 flex justify-center items-center bg-gray-300 animate-pulse">
+
+  </div>
+  )
+}
+
+export default DIvSkeleton

--- a/src/components/skeleton/ImageSkeleton.jsx
+++ b/src/components/skeleton/ImageSkeleton.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+function ImageSkeleton() {
+  return (
+    <div className="relative h-full w-full mb-4 flex justify-center items-center bg-gray-700 animate-pulse">
+    <svg
+      className="w-10 h-10 text-gray-200 dark:text-gray-600"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      viewBox="0 0 20 18"
+    >
+      <path d="M18 0H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2Zm-5.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3Zm4.376 10.481A1 1 0 0 1 16 15H4a1 1 0 0 1-.895-1.447l3.5-7A1 1 0 0 1 7.468 6a.965.965 0 0 1 .9.5l2.775 4.757 1.546-1.887a1 1 0 0 1 1.618.1l2.541 4a1 1 0 0 1 .028 1.011Z" />
+    </svg>
+  </div>
+  )
+}
+
+export default ImageSkeleton

--- a/src/components/skeleton/TextSkeleton.jsx
+++ b/src/components/skeleton/TextSkeleton.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function TextSkeleton() {
+  return (
+    <div className="h-10 bg-gray-700 rounded mb-4 sm:mb-6 w-3/4 mx-auto md:mx-0 animate-pulse"></div>
+  )
+}
+
+export default TextSkeleton

--- a/src/components/skeleton/sections/BottomBannerSkeleton.jsx
+++ b/src/components/skeleton/sections/BottomBannerSkeleton.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import ImageSkeleton from "../ImageSkeleton";
+
+const BottomBannerSkeleton = () => {
+  return (
+    <div className="bg-[#000625] flex flex-col items-center justify-center px-4 py-12 sm:py-20">
+      <div className="max-w-5xl w-full grid md:grid-cols-2 gap-8 items-center">
+        <div className="relative aspect-square md:order-1">
+          <div className="w-full h-full bg-gray-700 rounded-lg animate-pulse">
+            <ImageSkeleton />
+          </div>
+        </div>
+        <div className="text-white text-center md:text-left md:order-0">
+          <div className="h-10 bg-gray-700 rounded mb-4 sm:mb-6 w-3/4 mx-auto md:mx-0 animate-pulse"></div>
+          <div className="h-4 bg-gray-700 rounded mb-2 w-5/6 mx-auto md:mx-0 animate-pulse"></div>
+          <div className="h-4 bg-gray-700 rounded mb-6 sm:mb-8 w-2/3 mx-auto md:mx-0 animate-pulse"></div>
+          <div className="bg-gray-700 rounded-full h-10 sm:h-12 w-40 mx-auto md:mx-0 animate-pulse"></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BottomBannerSkeleton;

--- a/src/components/skeleton/sections/HowItWorksSkeleton.jsx
+++ b/src/components/skeleton/sections/HowItWorksSkeleton.jsx
@@ -1,0 +1,115 @@
+import React from "react";
+import ImageSkeleton from "../ImageSkeleton";
+
+const HowItWorksSkeleton = () => {
+  return (
+    <div
+      className="min-h-screen py-16 md:py-24 overflow-hidden bg-[#101428]"
+      id="how-it-works"
+    >
+      <div className="container mx-auto px-4 md:px-6 max-w-[1440px]">
+        {/* Header Skeleton */}
+        <div className="text-center mb-16 md:mb-24">
+          <div className="mx-auto mb-4 bg-gray-700 rounded h-8 w-40 animate-pulse"></div>
+          <div className="mx-auto bg-gray-700 rounded h-4 w-64 animate-pulse"></div>
+        </div>
+
+        {/* Timeline Skeleton */}
+        <div className="relative">
+          {/* Vertical Line Skeleton */}
+          <div className="absolute left-1/2 transform -translate-x-1/2 h-full flex flex-col items-center">
+            <div className="w-[5px] h-[5px] rounded-full bg-gray-700 animate-pulse"></div>
+            <div
+              className="w-[1px] h-full my-2 animate-pulse"
+              style={{
+                background:
+                  "repeating-linear-gradient(to bottom, #A3E6EB 0px, #A3E6EB 8px, transparent 8px, transparent 20px)"
+              }}
+            ></div>
+            <div className="w-[5px] h-[5px] rounded-full bg-gray-700 animate-pulse"></div>
+          </div>
+
+          {/* Steps Skeleton */}
+          <div className="space-y-32 md:space-y-40">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div key={index} className="relative pt-[70px] lg:pt-[10px] animate-pulse">
+                {/* Timeline Dot Skeleton */}
+                <div
+                  className="absolute left-[44.5%] sm:left-[46.5%] lg:left-[47.5%] xl:left-[48%] transform top-[30px] w-[50px] h-[50px] bg-gray-700 rounded-full flex items-center justify-center"
+                ></div>
+
+                {/* Content Skeleton */}
+                <div
+                  className={`flex ${
+                    index < 2 ? "lg:justify-end lg:pr-16" : "lg:justify-start lg:pl-16"
+                  } w-full lg:w-1/2 ${index < 2 ? "lg:ml-auto" : ""} justify-center px-4 lg:px-0`}
+                  style={{ zIndex: 20 }}
+                >
+                  <div className="max-w-[30rem] relative">
+                    <div className="px-4 lg:px-8 pt-2 pb-4 rounded-xl space-y-2">
+                      <div className="h-8 bg-gray-700 rounded w-1/2"></div>
+                      <div className="h-4 bg-gray-700 rounded w-full"></div>
+                      <div className="h-4 bg-gray-700 rounded w-5/6"></div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Image Skeletons for larger screens */}
+                {index === 0 && (
+                  <div
+                    className="hidden lg:flex absolute left-8 -space-x-4 md:left-12"
+                    style={{ top: "120px" }}
+                  >
+                    <div className="w-56 h-40 bg-gray-700 rounded animate-pulse">
+                      <ImageSkeleton/>
+                    </div>
+                    <div className="w-56 h-40 bg-gray-700 rounded animate-pulse">
+                      <ImageSkeleton/>
+                    </div>
+                  </div>
+                )}
+                {index === 2 && (
+                  <div
+                    className="hidden lg:flex absolute right-8 -space-x-4 md:right-12"
+                    style={{ top: "120px" }}
+                  >
+                    <div className="w-56 h-40 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                    <div className="w-48 h-40 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                  </div>
+                )}
+
+                {/* Mobile Image Skeletons */}
+                {index === 0 && (
+                  <div className="lg:hidden flex justify-center mt-8 -space-x-4">
+                    <div className="w-36 h-24 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                    <div className="w-36 h-24 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                  </div>
+                )}
+                {index === 2 && (
+                  <div className="lg:hidden flex justify-center mt-8 -space-x-4">
+                    <div className="w-36 h-24 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                    <div className="w-36 h-24 bg-gray-700 rounded animate-pulse">
+                    <ImageSkeleton/>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HowItWorksSkeleton;

--- a/src/components/skeleton/sections/TrendingEventsSkeleton.jsx
+++ b/src/components/skeleton/sections/TrendingEventsSkeleton.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import ImageSkeleton from "../ImageSkeleton";
+
+const TrendingEventsSkeleton = () => {
+  return (
+    <div className="h-auto w-full flex flex-col bg-[#101428] lg:px-4 py-8 lg:py-12 items-center">
+      {/* Section Header Skeleton */}
+      <div className="flex flex-col items-center mt-8 lg:mt-12 w-full">
+        <div className="items-start max-w-[1400px] px-4 mb-10 flex-col gap-4 lg:gap-0 lg:flex-row flex w-full">
+          <div className="w-full">
+            <div className="h-6 w-40 bg-gray-700 rounded-md animate-pulse mb-2"></div>
+            <div className="h-4 w-60 bg-gray-700 rounded-md animate-pulse"></div>
+          </div>
+          <div className="flex flex-wrap w-full gap-3 lg:gap-4 lg:items-end lg:justify-end">
+            <div className="h-10 w-28 bg-gray-700 rounded-full animate-pulse"></div>
+            <div className="h-10 w-28 bg-gray-700 rounded-full animate-pulse"></div>
+            <div className="h-10 w-28 bg-gray-700 rounded-full animate-pulse"></div>
+          </div>
+        </div>
+
+        {/* Event Cards Skeleton */}
+        <div className="grid lg:grid-cols-3 xl:grid-cols-4 px-4 md:grid-cols-2 grid-cols-1 max-w-[1400px] justify-between items-center gap-8 w-full">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="w-full bg-gray-800 p-4 rounded-lg animate-pulse"
+            >
+              <div className="h-40 w-full bg-gray-700 rounded-md">
+                <ImageSkeleton />
+              </div>
+              <div className="h-6 w-3/4 bg-gray-700 rounded-md mt-3"></div>
+              <div className="h-4 w-1/2 bg-gray-700 rounded-md mt-2"></div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Button Skeleton */}
+      <div className="mt-12 flex flex-col items-center">
+        <div className="h-10 w-40 bg-gray-700 rounded-full animate-pulse"></div>
+      </div>
+    </div>
+  );
+};
+
+export default TrendingEventsSkeleton;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -14,7 +14,11 @@ function Home() {
         <h1 className="mb-4 text-3xl font-bold text-gray-800">
           Welcome to Our Website
         </h1>
-        <img src="/Images/Vector.svg" className="absolute -top-52 right-0" />
+
+        <div>
+          {/* <ImageSkeleton/> */}
+          <img src="/Images/Vector.svg" className="absolute -top-52 right-0" />
+        </div>
         <TrendingEvent />
         <HowItWorksSection />
         <BottomBanner />


### PR DESCRIPTION
## Description  
<!-- Provide a brief summary of the changes in this PR. -->

This PR introduces a skeleton loading state for the "Make your own Event" section. The skeleton mimics the layout using animated placeholders to improve UX while content loads.

Changes:
Created skeleton components.

Used animate-pulse for smooth loading placeholders.

Maintained the original layout structure with flexbox and grid.

Placeholder elements replace the image, heading, text, and button.

Why this is needed:
Enhances user experience by providing a seamless loading effect.

Prevents content jumps when data is being fetched.

Keeps the layout visually consistent while loading.

How to Test:
Import and render EventSectionSkeleton where needed.

Verify that placeholders appear before actual content loads.

Let me know if you need any refinements! 🚀
## Related Issues  
<!-- Link related issues using `Closes #issue_number` or `Fixes #issue_number` -->
Close #13 

## Changes Made  
- [x ] List key changes made in this PR.
- created Eventsection skeleton and all the skeleton for all the sections on the landing page

## How to Test  
<!-- Describe how a reviewer can test these changes. -->
How to Test:
Import and render EventSectionSkeleton where needed.

Verify that placeholders appear before actual content loads.

## Screenshots (if applicable)  
<!-- Upload screenshots for UI-related changes. -->
![skeleton](https://github.com/user-attachments/assets/fd0d3ab6-2324-4789-8ed4-7e7995f65682)

## Checklist  
- [ x] My code follows the project's coding style.
- [ x] I have tested these changes locally.
- [ ] Documentation has been updated where necessary.
