### PR TITLE
feat: Reusable UI Component Library — Button, Input, Modal, Badge, Loader (#68)

### DIFF
--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,16 +1,16 @@
-'use client'
+"use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import z from "zod";
-import { Input } from "../input";
+import { Input } from "../ui/input";
 import { TbUserPlus } from "react-icons/tb";
 import { Button } from "../button";
 import { toast } from "react-toastify";
 import { motion } from "framer-motion";
 
 const forgotPasswordSchema = z.object({
-  email: z.email('Please enter a valid email address'),
+  email: z.email("Please enter a valid email address"),
 });
 
 type FormValues = z.infer<typeof forgotPasswordSchema>;
@@ -19,15 +19,15 @@ export default function ForgotPasswordForm() {
   const {
     handleSubmit,
     formState: { isSubmitting },
-    control
+    control,
   } = useForm({
     resolver: zodResolver(forgotPasswordSchema),
   });
 
   const onSubmit = async (data: FormValues) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log('Forgot Password data:', data);
-    toast.success('Magic link sent successful! (Demo)');
+    console.log("Forgot Password data:", data);
+    toast.success("Magic link sent successful! (Demo)");
   };
 
   const containerVariants = {
@@ -36,9 +36,9 @@ export default function ForgotPasswordForm() {
       opacity: 1,
       transition: {
         duration: 0.5,
-        staggerChildren: 0.12
-      }
-    }
+        staggerChildren: 0.12,
+      },
+    },
   };
 
   const itemVariants = {
@@ -46,8 +46,8 @@ export default function ForgotPasswordForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.4 }
-    }
+      transition: { duration: 0.4 },
+    },
   };
 
   const headerVariants = {
@@ -55,8 +55,8 @@ export default function ForgotPasswordForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.5 }
-    }
+      transition: { duration: 0.5 },
+    },
   };
 
   return (
@@ -70,10 +70,11 @@ export default function ForgotPasswordForm() {
         className="mb-10 text-center space-y-5"
         variants={headerVariants}
       >
-        <h2 className="text-3xl md:text-4xl font-bold">
-          Forgot Password
-        </h2>
-        <p className="text-primary-gray">No worries, we&apos;ll help you reset it and get you back to your events in no time.</p>
+        <h2 className="text-3xl md:text-4xl font-bold">Forgot Password</h2>
+        <p className="text-primary-gray">
+          No worries, we&apos;ll help you reset it and get you back to your
+          events in no time.
+        </p>
       </motion.div>
 
       <div>
@@ -99,11 +100,8 @@ export default function ForgotPasswordForm() {
               whileTap={{ scale: 0.98 }}
               transition={{ duration: 0.2 }}
             >
-              <Button
-                disabled={isSubmitting}
-                className="w-full py-4"
-              >
-                {isSubmitting ? 'Sending Magic Link...' : 'Send Magic Link'}
+              <Button disabled={isSubmitting} className="w-full py-4">
+                {isSubmitting ? "Sending Magic Link..." : "Send Magic Link"}
               </Button>
             </motion.div>
           </motion.div>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,9 +1,9 @@
-'use client'
+"use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import z from "zod";
-import { Input } from "../input";
+import { Input } from "../ui/input";
 import { TbUserPlus } from "react-icons/tb";
 import { Button } from "../button";
 import Link from "next/link";
@@ -11,8 +11,10 @@ import { toast } from "react-toastify";
 import { motion } from "framer-motion";
 
 const loginSchema = z.object({
-  email: z.email('Please enter a valid email address'),
-  password: z.string('Please enter your password').min(6, 'Password must be at least 6 characters'),
+  email: z.email("Please enter a valid email address"),
+  password: z
+    .string("Please enter your password")
+    .min(6, "Password must be at least 6 characters"),
 });
 
 type FormValues = z.infer<typeof loginSchema>;
@@ -21,15 +23,15 @@ export default function LoginForm() {
   const {
     handleSubmit,
     formState: { isSubmitting },
-    control
+    control,
   } = useForm({
     resolver: zodResolver(loginSchema),
   });
 
   const onSubmit = async (data: FormValues) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log('Login data:', data);
-    toast.success("Login successful! (Demo)")
+    console.log("Login data:", data);
+    toast.success("Login successful! (Demo)");
   };
 
   const containerVariants = {
@@ -38,9 +40,9 @@ export default function LoginForm() {
       opacity: 1,
       transition: {
         duration: 0.5,
-        staggerChildren: 0.12
-      }
-    }
+        staggerChildren: 0.12,
+      },
+    },
   };
 
   const itemVariants = {
@@ -48,8 +50,8 @@ export default function LoginForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.4 }
-    }
+      transition: { duration: 0.4 },
+    },
   };
 
   const headerVariants = {
@@ -57,8 +59,8 @@ export default function LoginForm() {
     visible: {
       opacity: 1,
       scale: 1,
-      transition: { duration: 0.5 }
-    }
+      transition: { duration: 0.5 },
+    },
   };
 
   return (
@@ -109,26 +111,17 @@ export default function LoginForm() {
               whileTap={{ scale: 0.98 }}
               transition={{ duration: 0.2 }}
             >
-              <Button
-                disabled={isSubmitting}
-                className="w-full py-4"
-              >
-                {isSubmitting ? 'Signing In...' : 'Sign In'}
+              <Button disabled={isSubmitting} className="w-full py-4">
+                {isSubmitting ? "Signing In..." : "Sign In"}
               </Button>
             </motion.div>
           </motion.div>
         </motion.form>
       </div>
 
-      <motion.p
-        className="text-center lg:text-xl mt-6"
-        variants={itemVariants}
-      >
-        Don&apos;t have an account?{' '}
-        <Link
-          href="/sign-up"
-          className="font-bold"
-        >
+      <motion.p className="text-center lg:text-xl mt-6" variants={itemVariants}>
+        Don&apos;t have an account?{" "}
+        <Link href="/sign-up" className="font-bold">
           Sign Up
         </Link>
       </motion.p>

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,26 +1,28 @@
-'use client'
+"use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import z from "zod";
-import { Input } from "../input";
+import { Input } from "../ui/input";
 import { TbUserPlus } from "react-icons/tb";
 import { Button } from "../button";
 import { toast } from "react-toastify";
 import { motion } from "framer-motion";
 
-const resetPasswordSchema = z.object({
-  password: z
-    .string("Password is required")
-    .min(6, 'Password must be at least 6 characters')
-    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
-    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
-    .regex(/[0-9]/, 'Password must contain at least one number'),
-  confirmPassword: z.string("Please confirm your password")
-}).refine((data) => data.password === data.confirmPassword, {
-  message: "Passwords don't match",
-  path: ["confirmPassword"],
-});
+const resetPasswordSchema = z
+  .object({
+    password: z
+      .string("Password is required")
+      .min(6, "Password must be at least 6 characters")
+      .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+      .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+      .regex(/[0-9]/, "Password must contain at least one number"),
+    confirmPassword: z.string("Please confirm your password"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
 
 type FormValues = z.infer<typeof resetPasswordSchema>;
 
@@ -28,15 +30,15 @@ export default function ResetPasswordForm() {
   const {
     handleSubmit,
     formState: { isSubmitting },
-    control
+    control,
   } = useForm({
     resolver: zodResolver(resetPasswordSchema),
   });
 
   const onSubmit = async (data: FormValues) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log('Reset password data:', data);
-    toast.success('reset password successful! (Demo)');
+    console.log("Reset password data:", data);
+    toast.success("reset password successful! (Demo)");
   };
 
   const containerVariants = {
@@ -45,9 +47,9 @@ export default function ResetPasswordForm() {
       opacity: 1,
       transition: {
         duration: 0.5,
-        staggerChildren: 0.12
-      }
-    }
+        staggerChildren: 0.12,
+      },
+    },
   };
 
   const itemVariants = {
@@ -55,8 +57,8 @@ export default function ResetPasswordForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.4 }
-    }
+      transition: { duration: 0.4 },
+    },
   };
 
   const headerVariants = {
@@ -64,8 +66,8 @@ export default function ResetPasswordForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.5 }
-    }
+      transition: { duration: 0.5 },
+    },
   };
 
   return (
@@ -119,11 +121,8 @@ export default function ResetPasswordForm() {
               whileTap={{ scale: 0.98 }}
               transition={{ duration: 0.2 }}
             >
-              <Button
-                disabled={isSubmitting}
-                className="w-full py-4"
-              >
-                {isSubmitting ? 'Reseting Password...' : 'Reset Password'}
+              <Button disabled={isSubmitting} className="w-full py-4">
+                {isSubmitting ? "Reseting Password..." : "Reset Password"}
               </Button>
             </motion.div>
           </motion.div>

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -1,9 +1,9 @@
-'use client'
+"use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import z from "zod";
-import { Input } from "../input";
+import { Input } from "../ui/input";
 import { TbUserPlus } from "react-icons/tb";
 import { Button } from "../button";
 import Link from "next/link";
@@ -13,16 +13,16 @@ import { FcGoogle } from "react-icons/fc";
 import { IoWallet } from "react-icons/io5";
 
 const signUpSchema = z.object({
-  firstName: z.string().min(1, 'First name is required'),
-  lastName: z.string().min(1, 'Last name is required'),
-  username: z.string().min(3, 'Username must be at least 3 characters'),
-  email: z.email('Please enter a valid email address'),
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  username: z.string().min(3, "Username must be at least 3 characters"),
+  email: z.email("Please enter a valid email address"),
   password: z
     .string("Password is required")
-    .min(6, 'Password must be at least 6 characters')
-    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
-    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
-    .regex(/[0-9]/, 'Password must contain at least one number')
+    .min(6, "Password must be at least 6 characters")
+    .regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+    .regex(/[a-z]/, "Password must contain at least one lowercase letter")
+    .regex(/[0-9]/, "Password must contain at least one number"),
 });
 
 type FormValues = z.infer<typeof signUpSchema>;
@@ -38,18 +38,18 @@ export default function SignUpForm() {
 
   const onSubmit = async (data: FormValues) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    console.log('Sign up data:', data);
-    toast.success('Account created successfully! (Demo)');
+    console.log("Sign up data:", data);
+    toast.success("Account created successfully! (Demo)");
   };
 
   const handleGoogleSignUp = () => {
-    console.log('Google sign up clicked');
-    toast.success('Google sign up (Demo)');
+    console.log("Google sign up clicked");
+    toast.success("Google sign up (Demo)");
   };
 
   const handleWalletSignUp = () => {
-    console.log('Wallet sign up clicked');
-    toast.success('Wallet sign up (Demo)');
+    console.log("Wallet sign up clicked");
+    toast.success("Wallet sign up (Demo)");
   };
 
   const containerVariants = {
@@ -58,9 +58,9 @@ export default function SignUpForm() {
       opacity: 1,
       transition: {
         duration: 0.5,
-        staggerChildren: 0.1
-      }
-    }
+        staggerChildren: 0.1,
+      },
+    },
   };
 
   const itemVariants = {
@@ -68,8 +68,8 @@ export default function SignUpForm() {
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.4 }
-    }
+      transition: { duration: 0.4 },
+    },
   };
 
   return (
@@ -157,11 +157,10 @@ export default function SignUpForm() {
                 disabled={isSubmitting}
                 className="w-full py-3 md:py-4 text-base md:text-lg mt-2"
               >
-                {isSubmitting ? 'Creating Account...' : 'Sign Up'}
+                {isSubmitting ? "Creating Account..." : "Sign Up"}
               </Button>
             </motion.div>
           </motion.div>
-
         </motion.form>
       </div>
 
@@ -215,15 +214,9 @@ export default function SignUpForm() {
         </motion.div>
       </motion.div>
 
-      <motion.p
-        className="text-center lg:text-xl mt-6"
-        variants={itemVariants}
-      >
-        Already have an account?{' '}
-        <Link
-          href="/login"
-          className="font-bold"
-        >
+      <motion.p className="text-center lg:text-xl mt-6" variants={itemVariants}>
+        Already have an account?{" "}
+        <Link href="/login" className="font-bold">
           Sign in
         </Link>
       </motion.p>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+
+type BadgeVariant = "primary" | "outline" | "subtle" | "success" | "danger";
+type BadgeSize = "sm" | "md";
+
+interface BadgeProps {
+  children: ReactNode;
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  className?: string;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  primary:
+    "bg-gradient-to-r from-[#4d21ff] to-[#21d4ff] text-white",
+  outline:
+    "border border-[#3a3c77] text-[#7c85ff] bg-transparent",
+  subtle:
+    "bg-white/10 text-white/80",
+  success:
+    "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30",
+  danger:
+    "bg-red-500/20 text-red-400 border border-red-500/30",
+};
+
+const sizeClasses: Record<BadgeSize, string> = {
+  sm: "px-2.5 py-0.5 text-[10px]",
+  md: "px-3 py-1 text-xs",
+};
+
+export function Badge({
+  children,
+  variant = "primary",
+  size = "md",
+  className = "",
+}: BadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-lg font-semibold ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+type LoaderSize = "sm" | "md" | "lg";
+type LoaderVariant = "spinner" | "dots" | "pulse";
+
+interface LoaderProps {
+  size?: LoaderSize;
+  variant?: LoaderVariant;
+  label?: string;
+  fullPage?: boolean;
+}
+
+const sizeMap: Record<LoaderSize, number> = { sm: 16, md: 32, lg: 48 };
+
+function Spinner({ size }: { size: number }) {
+  return (
+    <div
+      className="rounded-full border-2 border-white/20 border-t-transparent animate-spin"
+      style={{
+        width: size,
+        height: size,
+        borderTopColor: "#7c85ff",
+        borderRightColor: "#21d4ff",
+      }}
+    />
+  );
+}
+
+function Dots({ size }: { size: number }) {
+  const dot = size / 4;
+  return (
+    <div className="flex items-center gap-1.5">
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          className="rounded-full bg-gradient-to-br from-[#4d21ff] to-[#21d4ff]"
+          style={{ width: dot, height: dot }}
+          animate={{ opacity: [0.3, 1, 0.3], y: [0, -dot / 1.5, 0] }}
+          transition={{
+            duration: 0.9,
+            repeat: Infinity,
+            delay: i * 0.15,
+            ease: "easeInOut",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Pulse({ size }: { size: number }) {
+  return (
+    <div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+      <motion.div
+        className="absolute rounded-full bg-gradient-to-br from-[#4d21ff]/30 to-[#21d4ff]/30"
+        style={{ width: size, height: size }}
+        animate={{ scale: [1, 1.6], opacity: [0.6, 0] }}
+        transition={{ duration: 1.2, repeat: Infinity, ease: "easeOut" }}
+      />
+      <div
+        className="rounded-full bg-gradient-to-br from-[#4d21ff] to-[#21d4ff]"
+        style={{ width: size / 2.5, height: size / 2.5 }}
+      />
+    </div>
+  );
+}
+
+export function Loader({
+  size = "md",
+  variant = "spinner",
+  label,
+  fullPage = false,
+}: LoaderProps) {
+  const px = sizeMap[size];
+
+  const inner = (
+    <div className="flex flex-col items-center gap-3">
+      {variant === "spinner" && <Spinner size={px} />}
+      {variant === "dots" && <Dots size={px} />}
+      {variant === "pulse" && <Pulse size={px} />}
+      {label && <p className="text-sm text-white/60">{label}</p>}
+    </div>
+  );
+
+  if (fullPage) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#0b1025]/90 backdrop-blur-sm">
+        {inner}
+      </div>
+    );
+  }
+
+  return inner;
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+import { useEffect } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  children: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeClasses = {
+  sm: "max-w-sm",
+  md: "max-w-lg",
+  lg: "max-w-2xl",
+};
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  size = "md",
+}: ModalProps) {
+  // Lock scroll when open
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            className="fixed inset-0 z-40 bg-[#0a0f24]/80 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+
+          {/* Panel */}
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <motion.div
+              className={`relative w-full ${sizeClasses[size]} rounded-3xl border border-white/10 bg-[#0b1025] p-6 shadow-[0_40px_80px_rgba(10,16,40,0.7)]`}
+              initial={{ opacity: 0, scale: 0.92, y: 16 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.92, y: 16 }}
+              transition={{ duration: 0.25, ease: "easeOut" }}
+            >
+              {/* Gradient top border accent */}
+              <div className="absolute inset-x-0 top-0 h-[2px] rounded-t-3xl bg-gradient-to-r from-[#4d21ff] to-[#21d4ff]" />
+
+              {/* Close button */}
+              <button
+                onClick={onClose}
+                className="absolute right-4 top-4 rounded-full bg-white/10 p-1.5 text-white/60 transition hover:bg-white/20 hover:text-white"
+                aria-label="Close modal"
+              >
+                <X size={16} />
+              </button>
+
+              {(title || description) && (
+                <div className="mb-5 pr-6">
+                  {title && (
+                    <h2 className="text-xl font-semibold text-white">{title}</h2>
+                  )}
+                  {description && (
+                    <p className="mt-1 text-sm text-white/60">{description}</p>
+                  )}
+                </div>
+              )}
+
+              {children}
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,5 @@
+export { Button } from "./Button";
+export { Input } from "./Input";
+export { Modal } from "./Modal";
+export { Badge } from "./Badge";
+export { Loader } from "./Loader";

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,11 @@
-import { Control, useController, FieldValues, FieldPath } from "react-hook-form";
-import { cn } from "../lib/cn";
-import usePasswordToggle from "../hooks/usePasswordToggle";
+import {
+  Control,
+  useController,
+  FieldValues,
+  FieldPath,
+} from "react-hook-form";
+import { cn } from "../../lib/cn";
+import usePasswordToggle from "../../hooks/usePasswordToggle";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa6";
 import Link from "next/link";
 
@@ -13,7 +18,10 @@ type FormInputProps<TFieldValues extends FieldValues = FieldValues> = {
   disabled?: boolean;
   icon?: React.ReactNode;
   showForgotPassword?: boolean;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'name' | 'type' | 'disabled' | 'placeholder'>;
+} & Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "name" | "type" | "disabled" | "placeholder"
+>;
 
 export const Input = <TFieldValues extends FieldValues = FieldValues>({
   name,
@@ -41,10 +49,8 @@ export const Input = <TFieldValues extends FieldValues = FieldValues>({
     <div className="w-full space-y-3">
       {label && (
         <div className="flex justify-between">
-          <label htmlFor={name}>
-            {label}
-          </label>
-          {(isPassword && showForgotPassword) && (
+          <label htmlFor={name}>{label}</label>
+          {isPassword && showForgotPassword && (
             <Link href="/forgot-password">Forgot Password?</Link>
           )}
         </div>
@@ -57,7 +63,7 @@ export const Input = <TFieldValues extends FieldValues = FieldValues>({
             error
               ? "border-red-500 focus-within:ring-red-500"
               : "border-[#CCCCCCCC]",
-            disabled && "opacity-50 cursor-not-allowed"
+            disabled && "opacity-50 cursor-not-allowed",
           )}
         >
           {icon && (
@@ -75,7 +81,7 @@ export const Input = <TFieldValues extends FieldValues = FieldValues>({
             aria-invalid={!!error}
             className={cn(
               "w-full bg-transparent text-sm text-gray-900 placeholder-gray-500 outline-none",
-              disabled && "cursor-not-allowed"
+              disabled && "cursor-not-allowed",
             )}
           />
           {isPassword && (
@@ -86,13 +92,15 @@ export const Input = <TFieldValues extends FieldValues = FieldValues>({
               aria-label={showPassword ? "Hide password" : "Show password"}
               className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600"
             >
-              {showPassword ? <FaRegEyeSlash size={18} /> : <FaRegEye size={18} />}
+              {showPassword ? (
+                <FaRegEyeSlash size={18} />
+              ) : (
+                <FaRegEye size={18} />
+              )}
             </button>
           )}
         </div>
-        {error && (
-          <p className="text-xs text-red-600">{error.message}</p>
-        )}
+        {error && <p className="text-xs text-red-600">{error.message}</p>}
       </div>
     </div>
   );


### PR DESCRIPTION
Extracts and standardizes shared UI primitives into components/ui, 
consistent with VeriTix design tokens across all pages.

Components added:
- Button — primary/outline/ghost variants, sizes, loading & disabled states, link support
- Input — gradient border ring, label/error/hint, icon slots, password toggle
- Modal — animated overlay, scroll lock, Escape key, sm/md/lg sizes
- Badge — primary/outline/subtle/success/danger variants
- Loader — spinner/dots/pulse variants with optional label and fullPage overlay

All components use the VeriTix design tokens (#0b1025, #4d21ff→#21d4ff gradient, 
#7c85ff accents) and Framer Motion animations matching existing page patterns.
Barrel export added at components/ui/index.ts for clean imports.
Showcase page at /ui-showcase documents all variants.

Closes #68