### PR TITLE
Feat/fe 016 login page

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthLayout } from "@/components/auth/AuthLayout";
+
+export default function AuthGroupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthLayout>{children}</AuthLayout>;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,10 @@
+import { LoginForm } from "@/components/auth/LoginForm";
+
+export const metadata = {
+  title: "Login",
+  description: "Sign in to your account",
+};
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/components/shared/MotionWrapper.tsx
+++ b/src/components/shared/MotionWrapper.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { resolveMotionVariants, getTransition } from "@/lib/animations";
+import { useMotionPreferences } from "@/hooks/useMotionPreferences";
+
+type Props = {
+  children: React.ReactNode;
+  variants: any;
+  className?: string;
+};
+
+export function MotionWrapper({ children, variants, className }: Props) {
+  const { prefersReducedMotion } = useMotionPreferences();
+
+  const resolvedVariants = resolveMotionVariants(
+    variants,
+    prefersReducedMotion
+  );
+
+  return (
+    <motion.div
+      className={className}
+      variants={resolvedVariants}
+      initial="hidden"
+      animate="visible"
+      transition={getTransition(prefersReducedMotion)}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/hooks/useMotionPreferences.ts
+++ b/src/hooks/useMotionPreferences.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+
+export function useMotionPreferences() {
+  const prefersReducedMotion = useReducedMotion();
+
+  return {
+    prefersReducedMotion,
+    shouldAnimate: !prefersReducedMotion,
+  };
+}

--- a/src/lib/animations/motionVariants.ts
+++ b/src/lib/animations/motionVariants.ts
@@ -1,0 +1,11 @@
+import { Variants } from "framer-motion";
+
+export const fadeInUp: Variants = {
+  hidden: { opacity: 0, y: 40 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};


### PR DESCRIPTION
## 🚀 Summary

Replaces the placeholder `/login` page with the actual login experience using the shared AuthLayout and LoginForm.

---

## ✨ Changes

- Integrated `LoginForm` into `/login`
- Applied shared `AuthLayout` for consistent auth UI
- Removed placeholder login UI and copy
- Updated page metadata for login experience

---

## ✅ Acceptance Criteria

- [x] `/login` renders real login form
- [x] Shared auth layout is applied
- [x] Metadata reflects login experience
- [x] Placeholder UI removed

---

## 🧪 Testing

- Navigate to `/login`
- Verify form renders correctly
- Test responsiveness (mobile + desktop)
- Confirm no placeholder text remains

---

## 🔗 Related Issue

Closes #107