### PR TITLE
Feat/fe 005 next image migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Frontend CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main   # change if your default branch differs
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x] # adjust if needed
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build project
+        run: npm run build

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthLayout } from "@/components/auth/AuthLayout";
+
+export default function AuthGroupLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthLayout>{children}</AuthLayout>;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,10 @@
+import { LoginForm } from "@/components/auth/LoginForm";
+
+export const metadata = {
+  title: "Login",
+  description: "Sign in to your account",
+};
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/src/components/shared/MotionWrapper.tsx
+++ b/src/components/shared/MotionWrapper.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { resolveMotionVariants, getTransition } from "@/lib/animations";
+import { useMotionPreferences } from "@/hooks/useMotionPreferences";
+
+type Props = {
+  children: React.ReactNode;
+  variants: any;
+  className?: string;
+};
+
+export function MotionWrapper({ children, variants, className }: Props) {
+  const { prefersReducedMotion } = useMotionPreferences();
+
+  const resolvedVariants = resolveMotionVariants(
+    variants,
+    prefersReducedMotion
+  );
+
+  return (
+    <motion.div
+      className={className}
+      variants={resolvedVariants}
+      initial="hidden"
+      animate="visible"
+      transition={getTransition(prefersReducedMotion)}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/hooks/useMotionPreferences.ts
+++ b/src/hooks/useMotionPreferences.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+
+export function useMotionPreferences() {
+  const prefersReducedMotion = useReducedMotion();
+
+  return {
+    prefersReducedMotion,
+    shouldAnimate: !prefersReducedMotion,
+  };
+}

--- a/src/lib/animations/motionVariants.ts
+++ b/src/lib/animations/motionVariants.ts
@@ -1,0 +1,11 @@
+import { Variants } from "framer-motion";
+
+export const fadeInUp: Variants = {
+  hidden: { opacity: 0, y: 40 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};


### PR DESCRIPTION
## 🚀 Summary

Replaces raw `<img>` usage in key components with optimized `next/image` handling while preserving layout and responsiveness.

---

## ✨ Changes

- Introduced `AppImage` wrapper for consistent image handling
- Migrated EventCard and EventSummary to `next/image`
- Configured allowed image domains
- Preserved layout behavior using `fill` and aspect ratios
- Documented intentional `<img>` usage for upload previews

---

## ✅ Acceptance Criteria

- [x] User-facing images use `next/image` or documented alternative
- [x] Layout and responsiveness preserved
- [x] Lint warnings resolved or intentionally exempted

---

## 🧪 Testing

- Verify images render correctly across breakpoints
- Confirm no layout shift occurs
- Test image upload preview functionality
- Run lint to confirm no warnings remain

---

## 🔗 Related Issue

Closes #96
Closes #97 
Closes #107 
Closes #129 