### PR TITLE
feat: analytics dashboard improvements (closes #219, #220, #221, #222)

### DIFF
--- a/src/__tests__/useOrganizerAnalytics.test.ts
+++ b/src/__tests__/useOrganizerAnalytics.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useOrganizerAnalytics, type OrganizerAnalytics } from "@/hooks/useOrganizerAnalytics";
+
+const mockData: OrganizerAnalytics = {
+  revenue: [{ day: "Mon", revenue: 5000 }],
+  performance: [{ day: "Mon", value: 3000 }],
+  totalEarned: 100000,
+  payoutsQueued: 20000,
+  nextSettlementDays: 3,
+  checkInsLive: true,
+  doorsOpenInMinutes: 30,
+  ticketBreakdown: [{ type: "VIP", count: 10, revenue: 50000 }],
+  demographics: {
+    region: [{ label: "Lagos", count: 8, percentage: 80 }],
+    deviceType: [{ label: "Mobile", count: 9, percentage: 90 }],
+    referralSource: [{ label: "Instagram", count: 5, percentage: 50 }],
+  },
+};
+
+describe("useOrganizerAnalytics", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts in loading state", () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useOrganizerAnalytics());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns data on successful fetch", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    } as Response);
+
+    const { result } = renderHook(() => useOrganizerAnalytics());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when API returns non-ok response", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+    } as Response);
+
+    const { result } = renderHook(() => useOrganizerAnalytics());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe("Failed to fetch analytics");
+  });
+
+  it("sets error when fetch throws a network error", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useOrganizerAnalytics());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe("Network error");
+  });
+});

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -8,6 +8,8 @@ import { Card, CardHeader, StatDisplay } from '@/components/dashboard/Card'
 import { EventImage } from '@/components/dashboard/EventImage'
 import { RevenueChart } from '@/components/dashboard/charts/RevenueChart'
 import { PerformanceChart } from '@/components/dashboard/charts/PerformanceChart'
+import { TicketTypeChart } from '@/components/dashboard/charts/TicketTypeChart'
+import { DemographicsSection } from '@/components/dashboard/DemographicsSection'
 import { eventImages } from '@/components/dashboard/constants'
 import {
   demoRevenueData,
@@ -17,6 +19,7 @@ import {
   demoNextSettlementDays,
 } from '@/components/dashboard/demoData'
 import { useOrganizerAnalytics } from '@/hooks/useOrganizerAnalytics'
+import { exportAnalyticsCsv } from '@/lib/exportAnalyticsCsv'
 
 function formatCurrency(n: number) {
   return `₦ ${n.toLocaleString('en-NG', { minimumFractionDigits: 0 })}`
@@ -38,6 +41,8 @@ export default function DashboardPage() {
   const payoutsQueued = data?.payoutsQueued ?? demoPayoutsQueued
   const nextSettlementDays = data?.nextSettlementDays ?? demoNextSettlementDays
 
+  const hasData = !loading && data !== null
+
   return (
     <div className="dark min-h-screen md:h-screen overflow-y-auto md:overflow-hidden flex flex-col bg-[#101428]">
       <div className="relative px-4 py-12 sm:px-6 lg:px-8 flex-shrink-0">
@@ -54,6 +59,14 @@ export default function DashboardPage() {
           <div className="mb-12 flex flex-col sm:flex-row justify-center gap-4">
             <CTAButton href="/events/create" text="Get Started" variant="primary" />
             <CTAButton href="/events" text="Discover events" variant="secondary" />
+            <button
+              onClick={() => data && exportAnalyticsCsv(data)}
+              disabled={!hasData}
+              title={!hasData ? "No analytics data available to export" : undefined}
+              className="rounded-full border border-[#4D21FF] px-6 py-2 text-sm font-semibold text-[#21D4FF] transition hover:bg-[#4D21FF]/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Export CSV
+            </button>
           </div>
 
           <div className="grid gap-1 lg:grid-cols-3 h-[500px] gap-4 lg:gap-1">
@@ -160,6 +173,25 @@ export default function DashboardPage() {
               </Card>
             </ScrollColumn>
           </div>
+
+          {/* Ticket Type Breakdown — Issue #219 */}
+          {!loading && data?.ticketBreakdown && data.ticketBreakdown.length > 0 && (
+            <div className="mt-10">
+              <Card>
+                <CardHeader title="Ticket Type Breakdown" subtitle="Revenue and volume by ticket category" />
+                <div className="mt-4">
+                  <TicketTypeChart data={data.ticketBreakdown} />
+                </div>
+              </Card>
+            </div>
+          )}
+
+          {/* Demographics — Issue #221 */}
+          {!loading && data?.demographics && (
+            <div className="mt-10">
+              <DemographicsSection demographics={data.demographics} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/dashboard/DemographicsSection.tsx
+++ b/src/components/dashboard/DemographicsSection.tsx
@@ -1,0 +1,49 @@
+import type { Demographics } from "@/hooks/useOrganizerAnalytics";
+
+interface Props {
+  demographics: Demographics;
+}
+
+function DemoGroup({ title, items }: { title: string; items: { label: string; count: number; percentage: number }[] }) {
+  return (
+    <div className="rounded-lg bg-white/5 p-4">
+      <p className="mb-3 text-xs font-semibold uppercase text-[#21D4FF]">{title}</p>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div key={item.label} className="flex items-center justify-between text-xs text-[#21D4FF]">
+            <span className="truncate">{item.label}</span>
+            <span className="ml-2 shrink-0 font-semibold text-[#4D21FF]">
+              {item.count.toLocaleString()} ({item.percentage}%)
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DemographicsSection({ demographics }: Props) {
+  const hasData =
+    demographics.region.length > 0 ||
+    demographics.deviceType.length > 0 ||
+    demographics.referralSource.length > 0;
+
+  if (!hasData) return null;
+
+  return (
+    <section aria-label="Demographic breakdown">
+      <p className="mb-4 text-sm font-semibold uppercase text-[#21D4FF]">Audience Demographics</p>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {demographics.region.length > 0 && (
+          <DemoGroup title="Region" items={demographics.region} />
+        )}
+        {demographics.deviceType.length > 0 && (
+          <DemoGroup title="Device Type" items={demographics.deviceType} />
+        )}
+        {demographics.referralSource.length > 0 && (
+          <DemoGroup title="Referral Source" items={demographics.referralSource} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/charts/TicketTypeChart.tsx
+++ b/src/components/dashboard/charts/TicketTypeChart.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import type { TicketTypeBreakdown } from "@/hooks/useOrganizerAnalytics";
+
+const COLORS = ["#4D21FF", "#21D4FF", "#a78bfa", "#34d399", "#f59e0b", "#f87171"];
+
+interface Props {
+  data: TicketTypeBreakdown[];
+}
+
+interface TooltipPayload {
+  name: string;
+  value: number;
+  payload: TicketTypeBreakdown & { percentage: number };
+}
+
+function CustomTooltip({ active, payload }: { active?: boolean; payload?: TooltipPayload[] }) {
+  if (!active || !payload?.length) return null;
+  const { name, value, payload: item } = payload[0];
+  return (
+    <div className="rounded bg-[#1a2040] border border-[#4D21FF] px-3 py-2 text-xs text-[#21D4FF]">
+      <p className="font-semibold">{name}</p>
+      <p>Count: {value}</p>
+      <p>Revenue: ₦{item.revenue.toLocaleString("en-NG")}</p>
+      <p>Share: {item.percentage}%</p>
+    </div>
+  );
+}
+
+export function TicketTypeChart({ data }: Props) {
+  const total = data.reduce((s, d) => s + d.count, 0);
+  const chartData = data.map((d) => ({
+    ...d,
+    name: d.type,
+    value: d.count,
+    percentage: total > 0 ? Math.round((d.count / total) * 100) : 0,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <PieChart>
+        <Pie
+          data={chartData}
+          cx="50%"
+          cy="50%"
+          innerRadius={55}
+          outerRadius={85}
+          paddingAngle={3}
+          dataKey="value"
+        >
+          {chartData.map((_, i) => (
+            <Cell key={i} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip content={<CustomTooltip />} />
+        <Legend
+          formatter={(value) => (
+            <span className="text-xs text-[#21D4FF]">{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/hooks/useOrganizerAnalytics.ts
+++ b/src/hooks/useOrganizerAnalytics.ts
@@ -1,5 +1,23 @@
 import { useState, useEffect } from "react";
 
+export interface TicketTypeBreakdown {
+  type: string;
+  count: number;
+  revenue: number;
+}
+
+export interface DemographicItem {
+  label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface Demographics {
+  region: DemographicItem[];
+  deviceType: DemographicItem[];
+  referralSource: DemographicItem[];
+}
+
 export interface OrganizerAnalytics {
   revenue: { day: string; revenue: number }[];
   performance: { day: string; value: number }[];
@@ -8,6 +26,8 @@ export interface OrganizerAnalytics {
   nextSettlementDays: number;
   checkInsLive: boolean;
   doorsOpenInMinutes: number;
+  ticketBreakdown?: TicketTypeBreakdown[];
+  demographics?: Demographics;
 }
 
 async function fetchOrganizerAnalytics(): Promise<OrganizerAnalytics> {

--- a/src/lib/exportAnalyticsCsv.ts
+++ b/src/lib/exportAnalyticsCsv.ts
@@ -1,0 +1,64 @@
+import type { OrganizerAnalytics } from "@/hooks/useOrganizerAnalytics";
+
+function toCsv(rows: Record<string, string | number>[]): string {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0]);
+  const lines = [
+    headers.join(","),
+    ...rows.map((r) => headers.map((h) => JSON.stringify(r[h] ?? "")).join(",")),
+  ];
+  return lines.join("\n");
+}
+
+export function exportAnalyticsCsv(data: OrganizerAnalytics, dateRange?: string): void {
+  const suffix = dateRange ? ` (${dateRange})` : "";
+
+  const revenueRows = data.revenue.map((d) => ({ Day: d.day, Revenue: d.revenue }));
+  const performanceRows = data.performance.map((d) => ({ Day: d.day, Value: d.value }));
+  const summaryRows = [
+    { Metric: "Total Earned", Value: data.totalEarned },
+    { Metric: "Payouts Queued", Value: data.payoutsQueued },
+    { Metric: "Next Settlement (days)", Value: data.nextSettlementDays },
+  ];
+
+  const sections: string[] = [
+    `Summary${suffix}`,
+    toCsv(summaryRows),
+    "",
+    "Revenue by Day",
+    toCsv(revenueRows),
+    "",
+    "Performance by Day",
+    toCsv(performanceRows),
+  ];
+
+  if (data.ticketBreakdown?.length) {
+    const ticketRows = data.ticketBreakdown.map((t) => ({
+      "Ticket Type": t.type,
+      Count: t.count,
+      Revenue: t.revenue,
+    }));
+    sections.push("", "Ticket Type Breakdown", toCsv(ticketRows));
+  }
+
+  if (data.demographics) {
+    const { region, deviceType, referralSource } = data.demographics;
+    if (region.length) {
+      sections.push("", "Demographics - Region", toCsv(region.map((d) => ({ Label: d.label, Count: d.count, "Percentage (%)": d.percentage }))));
+    }
+    if (deviceType.length) {
+      sections.push("", "Demographics - Device Type", toCsv(deviceType.map((d) => ({ Label: d.label, Count: d.count, "Percentage (%)": d.percentage }))));
+    }
+    if (referralSource.length) {
+      sections.push("", "Demographics - Referral Source", toCsv(referralSource.map((d) => ({ Label: d.label, Count: d.count, "Percentage (%)": d.percentage }))));
+    }
+  }
+
+  const blob = new Blob([sections.join("\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `analytics${suffix}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Resolves all four analytics dashboard issues in a single PR.

### #219 — Ticket-type breakdown chart
- Added `TicketTypeChart` component using Recharts `PieChart` (donut style)
- Tooltips show absolute count, revenue (₦), and percentage share
- Renders correctly with a single ticket type
- Shown only when `ticketBreakdown` data is present in the API response

### #220 — Export analytics data as CSV
- Added `exportAnalyticsCsv` utility in `src/lib/exportAnalyticsCsv.ts`
- Exports summary, revenue by day, performance by day, ticket breakdown, and demographics sections
- Column headers are human-readable
- Export CSV button added to dashboard; disabled with tooltip when no data is available

### #221 — Demographic breakdown section
- Added `DemographicsSection` component showing region, device type, and referral source cards
- Each card shows count and percentage share
- Section is hidden gracefully when no demographic data is available
- Responsive grid layout (1 col mobile → 3 col desktop)

### #222 — Unit tests for `useOrganizerAnalytics`
- Added `src/__tests__/useOrganizerAnalytics.test.ts`
- Covers: loading state, successful API response, non-ok HTTP response, and network error
- All 28 tests pass (`npm test`)

Closes #219
Closes #220
Closes #221
Closes #222