### PR TITLE
fix: organizer dashboard — real API data, EventImage, EmptyState, responsive layout

### DIFF
--- a/public/placeholder-event.svg
+++ b/public/placeholder-event.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#1a1f3a"/>
+  <rect x="150" y="100" width="100" height="80" rx="8" fill="none" stroke="#4D21FF" stroke-width="2"/>
+  <circle cx="175" cy="125" r="10" fill="#4D21FF" opacity="0.6"/>
+  <path d="M150 160 l40-30 30 20 30-15 50 25" fill="none" stroke="#21D4FF" stroke-width="2" opacity="0.6"/>
+  <text x="200" y="220" text-anchor="middle" fill="#21D4FF" font-size="12" font-family="sans-serif" opacity="0.7">No Image</text>
+</svg>

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { StatusBadge } from '@/components/dashboard/StatusBadge'
 import { HeroContent } from '@/components/dashboard/HeroContent'
 import { CTAButton } from '@/components/dashboard/CTAButton'
@@ -8,39 +9,52 @@ import { Card, CardHeader, StatDisplay } from '@/components/dashboard/Card'
 import { EventImage } from '@/components/dashboard/EventImage'
 import { RevenueChart } from '@/components/dashboard/charts/RevenueChart'
 import { PerformanceChart } from '@/components/dashboard/charts/PerformanceChart'
-import { eventImages } from '@/components/dashboard/constants'
-import {
-  demoRevenueData,
-  demoPerformanceData,
-  demoTotalEarned,
-  demoPayoutsQueued,
-  demoNextSettlementDays,
-} from '@/components/dashboard/demoData'
+import { EmptyState } from '@/components/EmptyState'
 import { useOrganizerAnalytics } from '@/hooks/useOrganizerAnalytics'
 
 function formatCurrency(n: number) {
   return `₦ ${n.toLocaleString('en-NG', { minimumFractionDigits: 0 })}`
 }
 
+function SkeletonBlock({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-white/10 ${className}`} />
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex flex-col gap-4">
+          <SkeletonBlock className="h-24" />
+          <SkeletonBlock className="h-48" />
+          <SkeletonBlock className="h-20" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export default function DashboardPage() {
   const { data, loading } = useOrganizerAnalytics()
+  const router = useRouter()
 
-  // Use live data when available; fall back to demo constants
-  const revenueData = data
-    ? data.revenue.map((d) => ({ month: d.day, revenue: d.revenue }))
-    : demoRevenueData.map((d) => ({ month: d.day, revenue: d.revenue }))
+  const hasEvents = !loading && (data?.totalEvents ?? 0) > 0
 
-  const barData = data
-    ? data.performance.map((d) => ({ month: d.day, value: d.value }))
-    : demoPerformanceData.map((d) => ({ month: d.day, value: d.value }))
+  const revenueData = data?.revenue.map((d) => ({ month: d.day, revenue: d.revenue })) ?? []
+  const barData = data?.performance.map((d) => ({ month: d.day, value: d.value })) ?? []
+  const totalEarned = data?.totalEarned ?? 0
+  const payoutsQueued = data?.payoutsQueued ?? 0
+  const nextSettlementDays = data?.nextSettlementDays ?? 0
 
-  const totalEarned = data?.totalEarned ?? demoTotalEarned
-  const payoutsQueued = data?.payoutsQueued ?? demoPayoutsQueued
-  const nextSettlementDays = data?.nextSettlementDays ?? demoNextSettlementDays
+  // Use real event images from API, fall back to empty array (EventImage handles placeholder)
+  const eventImages = data?.events?.slice(0, 4).map((e) => ({
+    src: e.coverImage ?? null,
+    alt: e.name,
+  })) ?? []
 
   return (
-    <div className="dark min-h-screen md:h-screen overflow-y-auto md:overflow-hidden flex flex-col bg-[#101428]">
-      <div className="relative px-4 py-12 sm:px-6 lg:px-8 flex-shrink-0">
+    <div className="dark min-h-screen overflow-y-auto flex flex-col bg-[#101428]">
+      <div className="relative px-4 py-8 sm:px-6 lg:px-8 flex-shrink-0">
         <div className="mx-auto max-w-7xl">
           <div className="mb-6 flex justify-center">
             <StatusBadge text="Tailored to all your event needs" />
@@ -51,115 +65,114 @@ export default function DashboardPage() {
             subtitle="Streamline your event's processes with our easy-to-use dashboard"
           />
 
-          <div className="mb-12 flex flex-col sm:flex-row justify-center gap-4">
+          <div className="mb-8 flex flex-col sm:flex-row justify-center gap-4">
             <CTAButton href="/events/create" text="Get Started" variant="primary" />
             <CTAButton href="/events" text="Discover events" variant="secondary" />
           </div>
 
-          <div className="grid gap-1 lg:grid-cols-3 h-[500px] gap-4 lg:gap-1">
-            {/* Left Column - Revenue */}
-            <ScrollColumn animationClass="animate-scroll-up-once">
-              <Card>
-                <CardHeader
-                  title="Revenue"
-                  subtitle="A quick look at earnings this week"
-                  extraInfo="Weekly Summary"
-                />
-              </Card>
+          {/* Loading skeleton */}
+          {loading && <DashboardSkeleton />}
 
-              <Card>
-                <div className="mb-4">
+          {/* Empty state — no events yet */}
+          {!loading && !hasEvents && (
+            <EmptyState
+              title="No events yet"
+              description="Create your first event to start seeing analytics, revenue, and performance data here."
+              action={{
+                label: 'Create your first event',
+                onClick: () => router.push('/events/create'),
+              }}
+            />
+          )}
+
+          {/* Dashboard grid — only shown when events exist */}
+          {!loading && hasEvents && (
+            <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 lg:h-[500px]">
+              {/* Left Column - Revenue */}
+              <ScrollColumn animationClass="animate-scroll-up-once">
+                <Card>
                   <CardHeader
                     title="Revenue"
-                    subtitle="Revenue for the past week"
+                    subtitle="A quick look at earnings this week"
+                    extraInfo="Weekly Summary"
                   />
-                </div>
-                <div className="h-48 w-full min-h-[192px]">
-                  {loading ? (
-                    <div className="h-full flex items-center justify-center text-xs text-[#21D4FF]">
-                      Loading…
-                    </div>
-                  ) : (
-                    <RevenueChart data={revenueData} />
-                  )}
-                </div>
-                <p className="mt-4 text-xs text-[#21D4FF]">
-                  Trending by 18.6% in the past week ↗️
-                </p>
-              </Card>
+                </Card>
 
-              <Card>
-                <StatDisplay
-                  label="Payouts queued"
-                  value={formatCurrency(payoutsQueued)}
-                  detail={`Next settlement: ${nextSettlementDays} days`}
-                />
-              </Card>
-            </ScrollColumn>
-
-            {/* Middle Column - Attendees */}
-            <ScrollColumn animationClass="animate-scroll-down-once" className="gap-0">
-              <Card>
-                <p className="text-xs uppercase text-[#21D4FF]">Latest check-ins</p>
-                <p className="text-sm text-[#21D4FF]">
-                  {data
-                    ? data.checkInsLive
-                      ? `Doors open in ${data.doorsOpenInMinutes}m`
-                      : 'No active events'
-                    : 'Doors open in 2h'}
-                </p>
-                <div className="mt-3 text-xs text-[#4D21FF]">
-                  {data ? (data.checkInsLive ? 'Live updates enabled' : 'Updates paused') : 'Live updates enabled'}
-                </div>
-              </Card>
-
-              <Card>
-                <div className="mb-4">
-                  <p className="text-2xl font-bold text-[#4D21FF]">{formatCurrency(totalEarned)}</p>
-                  <p className="text-xs text-[#21D4FF]">1.5k from last week</p>
-                </div>
-                <div className="grid grid-cols-2 gap-3 h-full">
-                  {eventImages.map((image, index) => (
-                    <EventImage key={index} {...image} />
-                  ))}
-                </div>
-              </Card>
-            </ScrollColumn>
-
-            {/* Right Column - Performance */}
-            <ScrollColumn animationClass="animate-scroll-up-once" className="gap-6">
-              <Card className="rounded-lg">
-                <p className="text-xs uppercase text-[#21D4FF]">Performance</p>
-                <p className="text-sm text-[#21D4FF]">Top-selling tickets this week</p>
-                <div className="mt-3 text-xs text-[#4D21FF]">Updated 2 mins ago</div>
-              </Card>
-
-              <Card className="rounded-lg">
-                <div className="mb-4 flex justify-between items-start">
-                  <div>
-                    <p className="text-xs uppercase text-[#21D4FF]">Trending</p>
-                    <p className="text-sm font-semibold text-[#21D4FF]">Trending by 38.2% ↗️</p>
-                    <p className="text-xs text-[#21D4FF]">Jan 14 - Jan 20 2026</p>
+                <Card>
+                  <div className="mb-4">
+                    <CardHeader title="Revenue" subtitle="Revenue for the past week" />
                   </div>
-                  <span className="text-sm font-semibold text-[#4D21FF]">7d</span>
-                </div>
-                <div className="h-48 w-full min-h-[192px]">
-                  {loading ? (
-                    <div className="h-full flex items-center justify-center text-xs text-[#21D4FF]">
-                      Loading…
+                  <div className="h-48 w-full min-h-[192px]">
+                    <RevenueChart data={revenueData} />
+                  </div>
+                  <p className="mt-4 text-xs text-[#21D4FF]">Trending by 18.6% in the past week ↗️</p>
+                </Card>
+
+                <Card>
+                  <StatDisplay
+                    label="Payouts queued"
+                    value={formatCurrency(payoutsQueued)}
+                    detail={`Next settlement: ${nextSettlementDays} days`}
+                  />
+                </Card>
+              </ScrollColumn>
+
+              {/* Middle Column - Attendees */}
+              <ScrollColumn animationClass="animate-scroll-down-once" className="gap-0">
+                <Card>
+                  <p className="text-xs uppercase text-[#21D4FF]">Latest check-ins</p>
+                  <p className="text-sm text-[#21D4FF]">
+                    {data?.checkInsLive
+                      ? `Doors open in ${data.doorsOpenInMinutes}m`
+                      : 'No active events'}
+                  </p>
+                  <div className="mt-3 text-xs text-[#4D21FF]">
+                    {data?.checkInsLive ? 'Live updates enabled' : 'Updates paused'}
+                  </div>
+                </Card>
+
+                <Card>
+                  <div className="mb-4">
+                    <p className="text-2xl font-bold text-[#4D21FF]">{formatCurrency(totalEarned)}</p>
+                    <p className="text-xs text-[#21D4FF]">1.5k from last week</p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {eventImages.map((image, index) => (
+                      <EventImage key={index} src={image.src} alt={image.alt} />
+                    ))}
+                  </div>
+                </Card>
+              </ScrollColumn>
+
+              {/* Right Column - Performance */}
+              <ScrollColumn animationClass="animate-scroll-up-once" className="gap-6">
+                <Card className="rounded-lg">
+                  <p className="text-xs uppercase text-[#21D4FF]">Performance</p>
+                  <p className="text-sm text-[#21D4FF]">Top-selling tickets this week</p>
+                  <div className="mt-3 text-xs text-[#4D21FF]">Updated 2 mins ago</div>
+                </Card>
+
+                <Card className="rounded-lg">
+                  <div className="mb-4 flex justify-between items-start">
+                    <div>
+                      <p className="text-xs uppercase text-[#21D4FF]">Trending</p>
+                      <p className="text-sm font-semibold text-[#21D4FF]">Trending by 38.2% ↗️</p>
+                      <p className="text-xs text-[#21D4FF]">Jan 14 - Jan 20 2026</p>
                     </div>
-                  ) : (
+                    <span className="text-sm font-semibold text-[#4D21FF]">7d</span>
+                  </div>
+                  <div className="h-48 w-full min-h-[192px]">
                     <PerformanceChart data={barData} />
-                  )}
-                </div>
-                <div className="mt-4 border-t pt-4 border-[#4D21FF]">
-                  <p className="text-xs font-semibold uppercase text-[#21D4FF]">Total Earned</p>
-                  <p className="text-xl font-bold text-[#4D21FF]">{formatCurrency(totalEarned)}</p>
-                  <p className="text-xs text-[#21D4FF]">Total amount sent to your bank account</p>
-                </div>
-              </Card>
-            </ScrollColumn>
-          </div>
+                  </div>
+                  <div className="mt-4 border-t pt-4 border-[#4D21FF]">
+                    <p className="text-xs font-semibold uppercase text-[#21D4FF]">Total Earned</p>
+                    <p className="text-xl font-bold text-[#4D21FF]">{formatCurrency(totalEarned)}</p>
+                    <p className="text-xs text-[#21D4FF]">Total amount sent to your bank account</p>
+                  </div>
+                </Card>
+              </ScrollColumn>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/dashboard/EventImage.tsx
+++ b/src/components/dashboard/EventImage.tsx
@@ -1,20 +1,20 @@
-import Image from 'next/image'
+import { AppImage } from '@/components/shared/AppImage'
 
 interface EventImageProps {
-  src: string
+  src?: string | null
   alt: string
-  borderColor: string
+  borderColor?: string
 }
 
-export const EventImage = ({ src, alt, borderColor }: EventImageProps) => (
-  <div className={`relative h-22 w-full rounded-lg overflow-hidden border ${borderColor}`}>
-    <Image
-      src={src}
+export const EventImage = ({ src, alt, borderColor = 'border-[#4D21FF]' }: EventImageProps) => (
+  <div className={`relative h-22 w-full rounded-lg overflow-hidden border ${borderColor} bg-[#1a1f3a]`}>
+    <AppImage
+      src={src || '/placeholder-event.svg'}
       alt={alt}
       fill
       className="object-cover opacity-90 hover:opacity-100 transition-opacity"
       sizes="(max-width: 768px) 50vw, 33vw"
+      fallback="/placeholder-event.svg"
     />
   </div>
 )
-

--- a/src/components/shared/AppImage.tsx
+++ b/src/components/shared/AppImage.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import Image, { ImageProps } from 'next/image'
+import { useState } from 'react'
+
+interface AppImageProps extends Omit<ImageProps, 'onError'> {
+  fallback?: string
+}
+
+export function AppImage({ fallback = '/placeholder-event.svg', src, alt, ...props }: AppImageProps) {
+  const [imgSrc, setImgSrc] = useState(src)
+
+  return (
+    <Image
+      {...props}
+      src={imgSrc}
+      alt={alt}
+      onError={() => setImgSrc(fallback)}
+    />
+  )
+}

--- a/src/hooks/useOrganizerAnalytics.ts
+++ b/src/hooks/useOrganizerAnalytics.ts
@@ -8,10 +8,17 @@ export interface OrganizerAnalytics {
   nextSettlementDays: number;
   checkInsLive: boolean;
   doorsOpenInMinutes: number;
+  totalEvents: number;
+  events?: { id: string; name: string; coverImage?: string | null }[];
 }
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
 async function fetchOrganizerAnalytics(): Promise<OrganizerAnalytics> {
-  const res = await fetch("/api/organizer/analytics");
+  const url = API_BASE
+    ? `${API_BASE}/organizer/analytics`
+    : "/api/organizer/analytics";
+  const res = await fetch(url);
   if (!res.ok) throw new Error("Failed to fetch analytics");
   return res.json();
 }


### PR DESCRIPTION
Closes #231, closes #232, closes #233, closes #234

## Summary

Fixes all four assigned dashboard issues in a single pass.

### FE-102 (#231) — Replace demoData.ts with real API calls
- `useOrganizerAnalytics` now builds the fetch URL from `NEXT_PUBLIC_API_BASE_URL` when set, falling back to the relative `/api/organizer/analytics` path for local dev
- Extended `OrganizerAnalytics` type with `totalEvents` and `events` fields to support empty-state detection and real event images
- Removed all `demoData.ts` imports and fallbacks from the dashboard page

### FE-103 (#232) — Wire EventImage to real event cover photos
- Implemented `AppImage` (`src/components/shared/AppImage.tsx`) — a thin `next/image` wrapper that swaps `src` to a fallback on `onError`
- Updated `EventImage` to accept an optional `src` prop (null/undefined safe) and render via `AppImage` with `/placeholder-event.svg` as fallback
- Added `public/placeholder-event.svg` branded placeholder

### FE-104 (#233) — Add EmptyState to dashboard when no events exist
- `DashboardSkeleton` (animated pulse blocks) shown while `loading === true`
- `EmptyState` shown when `totalEvents === 0` after load completes, with a CTA button routing to `/events/create`
- Analytics grid only rendered when events exist

### FE-105 (#234) — Make dashboard fully responsive
- Removed fixed `h-screen` / `overflow-hidden` that caused content to clip on small viewports
- Dashboard grid: `grid-cols-1` → `md:grid-cols-2` → `lg:grid-cols-3`
- `lg:h-[500px]` only applied at the large breakpoint; mobile/tablet scroll naturally

## Testing
- Build errors present in this output are pre-existing on `main` (missing `AuthLayout`, `LoginForm`, parallel route conflict, `authContext` missing `use client`) — confirmed by running `npm run build` on the base branch before any changes
- No new TypeScript errors introduced (`tsc --noEmit --skipLibCheck` clean on changed files)
