### PR TITLE
feat: quick-action panel, StatusBadge variants, unit tests, recent-activity feed

### DIFF
--- a/src/__tests__/__snapshots__/dashboard-components.test.tsx.snap
+++ b/src/__tests__/__snapshots__/dashboard-components.test.tsx.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`StatusBadge > snapshot — active 1`] = `
+<div
+  aria-label="Status: Active"
+  class="inline-flex items-center gap-2 rounded-full border px-4 py-2 border-[#4D21FF] bg-[#000625]"
+>
+  <span
+    class="inline-block h-2 w-2 rounded-full bg-[#21D4FF]"
+  />
+  <span
+    class="text-sm text-[#21D4FF]"
+  >
+    Active
+  </span>
+</div>
+`;
+
+exports[`StatusBadge > snapshot — cancelled 1`] = `
+<div
+  aria-label="Status: Cancelled"
+  class="inline-flex items-center gap-2 rounded-full border px-4 py-2 border-red-700 bg-red-950/30"
+>
+  <span
+    class="inline-block h-2 w-2 rounded-full bg-red-400"
+  />
+  <span
+    class="text-sm text-red-400"
+  >
+    Cancelled
+  </span>
+</div>
+`;
+
+exports[`StatusBadge > snapshot — draft 1`] = `
+<div
+  aria-label="Status: Draft"
+  class="inline-flex items-center gap-2 rounded-full border px-4 py-2 border-yellow-600 bg-yellow-950/30"
+>
+  <span
+    class="inline-block h-2 w-2 rounded-full bg-yellow-400"
+  />
+  <span
+    class="text-sm text-yellow-400"
+  >
+    Draft
+  </span>
+</div>
+`;
+
+exports[`StatusBadge > snapshot — ended 1`] = `
+<div
+  aria-label="Status: Ended"
+  class="inline-flex items-center gap-2 rounded-full border px-4 py-2 border-gray-600 bg-gray-900/30"
+>
+  <span
+    class="inline-block h-2 w-2 rounded-full bg-gray-400"
+  />
+  <span
+    class="text-sm text-gray-400"
+  >
+    Ended
+  </span>
+</div>
+`;

--- a/src/__tests__/dashboard-components.test.tsx
+++ b/src/__tests__/dashboard-components.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Card, CardHeader, StatDisplay } from '../components/dashboard/Card'
+import { StatusBadge, EventStatus } from '../components/dashboard/StatusBadge'
+
+// ─── Card ────────────────────────────────────────────────────────────────────
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(<Card>Hello</Card>)
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+  })
+
+  it('applies extra className', () => {
+    const { container } = render(<Card className="rounded-lg">content</Card>)
+    expect(container.firstChild).toHaveClass('rounded-lg')
+  })
+})
+
+describe('CardHeader', () => {
+  it('renders title', () => {
+    render(<CardHeader title="Revenue" />)
+    expect(screen.getByText('Revenue')).toBeInTheDocument()
+  })
+
+  it('renders optional subtitle when provided', () => {
+    render(<CardHeader title="Revenue" subtitle="This week" />)
+    expect(screen.getByText('This week')).toBeInTheDocument()
+  })
+
+  it('does not render subtitle when omitted', () => {
+    render(<CardHeader title="Revenue" />)
+    expect(screen.queryByText('This week')).not.toBeInTheDocument()
+  })
+
+  it('renders optional extraInfo when provided', () => {
+    render(<CardHeader title="Revenue" extraInfo="Weekly Summary" />)
+    expect(screen.getByText('Weekly Summary')).toBeInTheDocument()
+  })
+})
+
+describe('StatDisplay', () => {
+  it('renders label, value and detail', () => {
+    render(<StatDisplay label="Payouts" value="₦ 50,000" detail="Next: 3 days" />)
+    expect(screen.getByText('Payouts')).toBeInTheDocument()
+    expect(screen.getByText('₦ 50,000')).toBeInTheDocument()
+    expect(screen.getByText('Next: 3 days')).toBeInTheDocument()
+  })
+})
+
+// ─── StatusBadge ─────────────────────────────────────────────────────────────
+
+const VARIANTS: { status: EventStatus; label: string }[] = [
+  { status: 'active',    label: 'Active' },
+  { status: 'draft',     label: 'Draft' },
+  { status: 'ended',     label: 'Ended' },
+  { status: 'cancelled', label: 'Cancelled' },
+]
+
+describe('StatusBadge', () => {
+  it.each(VARIANTS)('renders $status variant with correct text', ({ status, label }) => {
+    render(<StatusBadge status={status} text={label} />)
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it.each(VARIANTS)('has accessible aria-label for $status', ({ status, label }) => {
+    render(<StatusBadge status={status} text={label} />)
+    expect(screen.getByLabelText(`Status: ${label}`)).toBeInTheDocument()
+  })
+
+  it('defaults to active styling when no status prop given', () => {
+    render(<StatusBadge text="Active" />)
+    expect(screen.getByLabelText('Status: Active')).toBeInTheDocument()
+  })
+
+  it('snapshot — active', () => {
+    const { container } = render(<StatusBadge status="active" text="Active" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('snapshot — draft', () => {
+    const { container } = render(<StatusBadge status="draft" text="Draft" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('snapshot — ended', () => {
+    const { container } = render(<StatusBadge status="ended" text="Ended" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('snapshot — cancelled', () => {
+    const { container } = render(<StatusBadge status="cancelled" text="Cancelled" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -3,6 +3,8 @@
 import { StatusBadge } from '@/components/dashboard/StatusBadge'
 import { HeroContent } from '@/components/dashboard/HeroContent'
 import { CTAButton } from '@/components/dashboard/CTAButton'
+import { QuickActions } from '@/components/dashboard/QuickActions'
+import { RecentActivity } from '@/components/dashboard/RecentActivity'
 import { ScrollColumn } from '@/components/dashboard/ScrollColumn'
 import { Card, CardHeader, StatDisplay } from '@/components/dashboard/Card'
 import { EventImage } from '@/components/dashboard/EventImage'
@@ -51,10 +53,12 @@ export default function DashboardPage() {
             subtitle="Streamline your event's processes with our easy-to-use dashboard"
           />
 
-          <div className="mb-12 flex flex-col sm:flex-row justify-center gap-4">
+          <div className="mb-8 flex flex-col sm:flex-row justify-center gap-4">
             <CTAButton href="/events/create" text="Get Started" variant="primary" />
             <CTAButton href="/events" text="Discover events" variant="secondary" />
           </div>
+
+          <QuickActions />
 
           <div className="grid gap-1 lg:grid-cols-3 h-[500px] gap-4 lg:gap-1">
             {/* Left Column - Revenue */}
@@ -159,6 +163,10 @@ export default function DashboardPage() {
                 </div>
               </Card>
             </ScrollColumn>
+          </div>
+
+          <div className="mt-8">
+            <RecentActivity />
           </div>
         </div>
       </div>

--- a/src/app/(protected)/events/manage/page.tsx
+++ b/src/app/(protected)/events/manage/page.tsx
@@ -1,410 +1,87 @@
-"use client";
+'use client'
 
-import { useParams, useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import Link from 'next/link'
+import { StatusBadge, EventStatus } from '@/components/dashboard/StatusBadge'
 
-// Mock data
-const MOCK_EVENTS = {
-  "1": {
-    id: "1",
-    name: "Summer Music Festival",
-    date: "2026-07-15",
-    time: "18:00",
-    location: "Central Park, New York",
-    description:
-      "An unforgettable evening of live music featuring top artists.",
-    ticketPrice: 45.0,
-    totalTickets: 500,
-    soldTickets: 342,
-    revenue: 15390.0,
-    ownerId: "user-123",
-  },
-  "2": {
-    id: "2",
-    name: "Tech Conference 2026",
-    date: "2026-08-20",
-    time: "09:00",
-    location: "Convention Center, San Francisco",
-    description: "Join industry leaders for cutting-edge tech insights.",
-    ticketPrice: 299.0,
-    totalTickets: 200,
-    soldTickets: 156,
-    revenue: 46644.0,
-    ownerId: "user-456",
-  },
-};
+interface ManagedEvent {
+  id: string
+  name: string
+  date: string
+  location: string
+  ticketsSold: number
+  totalTickets: number
+  status: EventStatus
+}
 
-const CURRENT_USER_ID = "user-123"; // Mock current user
+const MOCK_EVENTS: ManagedEvent[] = [
+  { id: '1', name: 'Summer Music Festival',  date: '2026-07-15', location: 'Central Park, NY',          ticketsSold: 342, totalTickets: 500, status: 'active' },
+  { id: '2', name: 'Tech Conference 2026',   date: '2026-08-20', location: 'Convention Center, SF',     ticketsSold: 156, totalTickets: 200, status: 'active' },
+  { id: '3', name: 'Lagos Art Fair',         date: '2026-06-01', location: 'Eko Hotel, Lagos',          ticketsSold: 80,  totalTickets: 300, status: 'draft' },
+  { id: '4', name: 'Afrobeats Night Out',    date: '2025-12-31', location: 'O2 Arena, London',          ticketsSold: 600, totalTickets: 600, status: 'ended' },
+  { id: '5', name: 'Web3 Summit',            date: '2026-03-10', location: 'Dubai World Trade Centre',  ticketsSold: 0,   totalTickets: 400, status: 'cancelled' },
+]
 
-export default function ManageEventPage() {
-  const params = useParams();
-  const router = useRouter();
-  const eventId = params.eventId as string;
+const STATUS_LABELS: Record<EventStatus, string> = {
+  active:    'Active',
+  draft:     'Draft',
+  ended:     'Ended',
+  cancelled: 'Cancelled',
+}
 
-  const [event, setEvent] = useState<(typeof MOCK_EVENTS)["1"] | null>(null);
-  const [isOwner, setIsOwner] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    // Simulate API call
-    setTimeout(() => {
-      const mockEvent = MOCK_EVENTS[eventId as keyof typeof MOCK_EVENTS];
-
-      if (!mockEvent) {
-        setLoading(false);
-        return;
-      }
-
-      setEvent(mockEvent);
-      setIsOwner(mockEvent.ownerId === CURRENT_USER_ID);
-      setLoading(false);
-    }, 500);
-  }, [eventId]);
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="animate-pulse text-gray-600">Loading...</div>
-      </div>
-    );
-  }
-
-  if (!event) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full text-center">
-          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="w-8 h-8 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">
-            Event Not Found
-          </h2>
-          <p className="text-gray-600 mb-6">
-            This event doesn&apos;t exist or has been removed.
-          </p>
-          <button
-            onClick={() => router.push("/events")}
-            className="bg-purple-600 text-white px-6 py-2 rounded-lg hover:bg-purple-700 transition"
-          >
-            Back to Events
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  if (!isOwner) {
-    return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full text-center">
-          <div className="w-16 h-16 bg-yellow-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="w-8 h-8 text-yellow-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-              />
-            </svg>
-          </div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">
-            Access Denied
-          </h2>
-          <p className="text-gray-600 mb-6">
-            You don&apos;t have permission to manage this event.
-          </p>
-          <button
-            onClick={() => router.push("/events")}
-            className="bg-purple-600 text-white px-6 py-2 rounded-lg hover:bg-purple-700 transition"
-          >
-            Back to Events
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  const soldPercentage = (event.soldTickets / event.totalTickets) * 100;
-  const availableTickets = event.totalTickets - event.soldTickets;
-
+export default function ManageEventsPage() {
   return (
-    <div className="min-h-screen bg-gray-50 py-8 px-4">
-      <div className="max-w-6xl mx-auto">
-        {/* Header */}
-        <div className="mb-8">
-          <button
-            onClick={() => router.push("/events")}
-            className="text-purple-600 hover:text-purple-700 mb-4 flex items-center gap-2"
+    <div className="min-h-screen bg-[#101428] py-10 px-4">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 flex items-center justify-between">
+          <h1 className="text-3xl font-bold text-white">Manage Events</h1>
+          <Link
+            href="/events/create"
+            className="rounded-lg bg-[linear-gradient(135deg,#4D21FF_0%,#21D4FF_100%)] px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4D21FF]"
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            Back to Events
-          </button>
-          <h1 className="text-3xl font-bold text-gray-900">Manage Event</h1>
+            + Create Event
+          </Link>
         </div>
 
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white rounded-xl shadow p-6">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-blue-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <p className="text-sm text-gray-600">Tickets Sold</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  {event.soldTickets}
-                </p>
-              </div>
-            </div>
-            <p className="text-xs text-gray-500">
-              of {event.totalTickets} total
-            </p>
-          </div>
-
-          <div className="bg-white rounded-xl shadow p-6">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-green-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <p className="text-sm text-gray-600">Revenue</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  ${event.revenue.toLocaleString()}
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow p-6">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-purple-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <p className="text-sm text-gray-600">Available</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  {availableTickets}
-                </p>
-              </div>
-            </div>
-            <p className="text-xs text-gray-500">
-              {soldPercentage.toFixed(0)}% sold
-            </p>
-          </div>
-
-          <div className="bg-white rounded-xl shadow p-6">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="w-10 h-10 bg-orange-100 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-orange-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <p className="text-sm text-gray-600">Ticket Price</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  ${event.ticketPrice}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Event Details */}
-          <div className="lg:col-span-2 space-y-6">
-            <div className="bg-white rounded-xl shadow p-6">
-              <h2 className="text-xl font-bold text-gray-900 mb-4">
-                Event Details
-              </h2>
-              <div className="space-y-4">
-                <div>
-                  <p className="text-sm font-medium text-gray-600">
-                    Event Name
-                  </p>
-                  <p className="text-lg text-gray-900">{event.name}</p>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <p className="text-sm font-medium text-gray-600">Date</p>
-                    <p className="text-gray-900">
-                      {new Date(event.date).toLocaleDateString("en-US", {
-                        weekday: "long",
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </p>
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-gray-600">Time</p>
-                    <p className="text-gray-900">{event.time}</p>
-                  </div>
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-gray-600">Location</p>
-                  <p className="text-gray-900">{event.location}</p>
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-gray-600">
-                    Description
-                  </p>
-                  <p className="text-gray-900">{event.description}</p>
-                </div>
-              </div>
-            </div>
-
-            {/* Sales Progress */}
-            <div className="bg-white rounded-xl shadow p-6">
-              <h2 className="text-xl font-bold text-gray-900 mb-4">
-                Sales Progress
-              </h2>
-              <div className="mb-4">
-                <div className="flex justify-between text-sm mb-2">
-                  <span className="text-gray-600">Tickets Sold</span>
-                  <span className="font-medium text-gray-900">
-                    {soldPercentage.toFixed(1)}%
-                  </span>
-                </div>
-                <div className="w-full bg-gray-200 rounded-full h-3">
-                  <div
-                    className="bg-gradient-to-r from-purple-600 to-blue-600 h-3 rounded-full transition-all"
-                    style={{ width: `${soldPercentage}%` }}
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-3 gap-4 text-center">
-                <div>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {event.soldTickets}
-                  </p>
-                  <p className="text-xs text-gray-600">Sold</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {availableTickets}
-                  </p>
-                  <p className="text-xs text-gray-600">Available</p>
-                </div>
-                <div>
-                  <p className="text-2xl font-bold text-gray-900">
-                    {event.totalTickets}
-                  </p>
-                  <p className="text-xs text-gray-600">Total</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Actions */}
-          <div className="space-y-6">
-            <div className="bg-white rounded-xl shadow p-6">
-              <h2 className="text-xl font-bold text-gray-900 mb-4">
-                Quick Actions
-              </h2>
-              <div className="space-y-3">
-                <button className="w-full bg-purple-600 text-white px-4 py-3 rounded-lg hover:bg-purple-700 transition font-medium">
-                  Edit Event
-                </button>
-                <button className="w-full border border-gray-300 text-gray-700 px-4 py-3 rounded-lg hover:bg-gray-50 transition font-medium">
-                  View Public Page
-                </button>
-                <button className="w-full border border-gray-300 text-gray-700 px-4 py-3 rounded-lg hover:bg-gray-50 transition font-medium">
-                  Download Report
-                </button>
-                <button className="w-full border border-red-300 text-red-600 px-4 py-3 rounded-lg hover:bg-red-50 transition font-medium">
-                  Cancel Event
-                </button>
-              </div>
-            </div>
-
-            <div className="bg-gradient-to-br from-purple-100 to-blue-100 rounded-xl p-6">
-              <h3 className="font-bold text-gray-900 mb-2">Event Status</h3>
-              <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                <span className="text-sm text-gray-700">Active & Selling</span>
-              </div>
-              <p className="text-xs text-gray-600 mt-3">
-                Your event is live and accepting ticket purchases.
-              </p>
-            </div>
-          </div>
+        <div className="overflow-x-auto rounded-xl border border-[#4D21FF]/30 bg-[#000625]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[#4D21FF]/30 text-left text-xs uppercase tracking-wider text-[#21D4FF]">
+                <th className="px-6 py-4">Event</th>
+                <th className="px-6 py-4">Date</th>
+                <th className="px-6 py-4">Location</th>
+                <th className="px-6 py-4">Tickets Sold</th>
+                <th className="px-6 py-4">Status</th>
+                <th className="px-6 py-4">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#4D21FF]/20">
+              {MOCK_EVENTS.map((event) => (
+                <tr key={event.id} className="transition-colors hover:bg-[#4D21FF]/5">
+                  <td className="px-6 py-4 font-medium text-white">{event.name}</td>
+                  <td className="px-6 py-4 text-[#21D4FF]/80">
+                    {new Date(event.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                  </td>
+                  <td className="px-6 py-4 text-[#21D4FF]/80">{event.location}</td>
+                  <td className="px-6 py-4 text-[#21D4FF]/80">
+                    {event.ticketsSold} / {event.totalTickets}
+                  </td>
+                  <td className="px-6 py-4">
+                    <StatusBadge status={event.status} text={STATUS_LABELS[event.status]} />
+                  </td>
+                  <td className="px-6 py-4">
+                    <Link
+                      href={`/events/manage/${event.id}`}
+                      className="text-[#4D21FF] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+                    >
+                      Manage →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/dashboard/QuickActions.tsx
+++ b/src/components/dashboard/QuickActions.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { PlusCircle, Ticket, BarChart2 } from 'lucide-react'
+
+const ACTIONS = [
+  { href: '/events/create', label: 'Create Event',    Icon: PlusCircle,  variant: 'primary' },
+  { href: '/events/manage', label: 'Manage Tickets',  Icon: Ticket,      variant: 'secondary' },
+  { href: '/events',        label: 'View Analytics',  Icon: BarChart2,   variant: 'secondary' },
+] as const
+
+export const QuickActions = () => (
+  <section
+    aria-label="Quick actions"
+    className="mx-auto mb-10 max-w-2xl rounded-xl border border-[#4D21FF]/40 bg-[#000625]/60 p-6"
+  >
+    <p className="mb-4 text-xs uppercase tracking-widest text-[#21D4FF]">Quick Actions</p>
+    <div className="flex flex-col sm:flex-row gap-3">
+      {ACTIONS.map(({ href, label, Icon, variant }) => (
+        <Link
+          key={href}
+          href={href}
+          className={
+            variant === 'primary'
+              ? 'flex flex-1 items-center justify-center gap-2 rounded-lg bg-[linear-gradient(135deg,#4D21FF_0%,#21D4FF_100%)] px-5 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4D21FF]'
+              : 'flex flex-1 items-center justify-center gap-2 rounded-lg border border-[#4D21FF] bg-transparent px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4D21FF]'
+          }
+        >
+          <Icon size={16} aria-hidden="true" />
+          {label}
+        </Link>
+      ))}
+    </div>
+  </section>
+)

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Link from 'next/link'
+import { Ticket, Globe, ShieldCheck, LucideIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+export type ActivityType = 'ticket_sold' | 'event_published' | 'verification_scan'
+
+export interface ActivityEntry {
+  id: string
+  type: ActivityType
+  description: string
+  timestamp: string // ISO string
+}
+
+const TYPE_META: Record<ActivityType, { Icon: LucideIcon; color: string }> = {
+  ticket_sold:        { Icon: Ticket,      color: 'text-[#21D4FF]' },
+  event_published:    { Icon: Globe,       color: 'text-green-400' },
+  verification_scan:  { Icon: ShieldCheck, color: 'text-yellow-400' },
+}
+
+function relativeTime(iso: string): string {
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 60)   return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+// Demo data — replace with real API call when backend is ready
+const DEMO_FEED: ActivityEntry[] = [
+  { id: '1', type: 'ticket_sold',       description: 'Ticket sold for Summer Music Festival',  timestamp: new Date(Date.now() - 2 * 60000).toISOString() },
+  { id: '2', type: 'event_published',   description: 'Tech Conference 2026 published',          timestamp: new Date(Date.now() - 15 * 60000).toISOString() },
+  { id: '3', type: 'verification_scan', description: 'Entry scan at Lagos Art Fair',            timestamp: new Date(Date.now() - 45 * 60000).toISOString() },
+  { id: '4', type: 'ticket_sold',       description: 'Ticket sold for Tech Conference 2026',   timestamp: new Date(Date.now() - 2 * 3600000).toISOString() },
+  { id: '5', type: 'ticket_sold',       description: 'Ticket sold for Summer Music Festival',  timestamp: new Date(Date.now() - 3 * 3600000).toISOString() },
+  { id: '6', type: 'verification_scan', description: 'Entry scan at Summer Music Festival',    timestamp: new Date(Date.now() - 5 * 3600000).toISOString() },
+  { id: '7', type: 'event_published',   description: 'Lagos Art Fair published',               timestamp: new Date(Date.now() - 8 * 3600000).toISOString() },
+  { id: '8', type: 'ticket_sold',       description: 'Ticket sold for Lagos Art Fair',         timestamp: new Date(Date.now() - 10 * 3600000).toISOString() },
+  { id: '9', type: 'ticket_sold',       description: 'Ticket sold for Tech Conference 2026',   timestamp: new Date(Date.now() - 12 * 3600000).toISOString() },
+  { id: '10', type: 'verification_scan', description: 'Entry scan at Tech Conference 2026',   timestamp: new Date(Date.now() - 20 * 3600000).toISOString() },
+]
+
+function SkeletonRow() {
+  return (
+    <div className="flex items-center gap-3 animate-pulse">
+      <div className="h-8 w-8 rounded-full bg-[#4D21FF]/20 shrink-0" />
+      <div className="flex-1 space-y-1">
+        <div className="h-3 w-3/4 rounded bg-[#4D21FF]/20" />
+        <div className="h-2 w-1/4 rounded bg-[#4D21FF]/10" />
+      </div>
+    </div>
+  )
+}
+
+export const RecentActivity = () => {
+  const [feed, setFeed] = useState<ActivityEntry[] | null>(null)
+
+  useEffect(() => {
+    // Simulate async fetch; swap for real API call later
+    const t = setTimeout(() => setFeed(DEMO_FEED), 600)
+    return () => clearTimeout(t)
+  }, [])
+
+  return (
+    <section
+      aria-label="Recent activity"
+      className="rounded-xl border border-[#4D21FF]/40 bg-[#000625]/60 p-6"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-xs uppercase tracking-widest text-[#21D4FF]">Recent Activity</p>
+        <Link href="/events" className="text-xs text-[#4D21FF] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]">
+          View all
+        </Link>
+      </div>
+
+      <ul className="space-y-4">
+        {feed === null
+          ? Array.from({ length: 5 }).map((_, i) => <li key={i}><SkeletonRow /></li>)
+          : feed.slice(0, 10).map((entry) => {
+              const { Icon, color } = TYPE_META[entry.type]
+              return (
+                <li key={entry.id} className="flex items-start gap-3">
+                  <span className={`mt-0.5 shrink-0 ${color}`} aria-hidden="true">
+                    <Icon size={18} />
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="truncate text-sm text-white">{entry.description}</p>
+                    <p className="text-xs text-[#21D4FF]/70">{relativeTime(entry.timestamp)}</p>
+                  </div>
+                </li>
+              )
+            })}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/dashboard/StatusBadge.tsx
+++ b/src/components/dashboard/StatusBadge.tsx
@@ -1,11 +1,26 @@
+export type EventStatus = 'active' | 'draft' | 'ended' | 'cancelled'
+
 interface BadgeProps {
   text: string
+  status?: EventStatus
 }
 
-export const StatusBadge = ({ text }: BadgeProps) => (
-  <div className="inline-flex items-center gap-2 rounded-full border px-4 py-2 border-[#4D21FF] bg-[#000625]">
-    <span className="inline-block h-2 w-2 rounded-full bg-[#21D4FF]" />
-    <span className="text-sm text-[#21D4FF]">{text}</span>
-  </div>
-)
+const statusStyles: Record<EventStatus, { dot: string; text: string; border: string; bg: string }> = {
+  active:    { dot: 'bg-[#21D4FF]', text: 'text-[#21D4FF]', border: 'border-[#4D21FF]', bg: 'bg-[#000625]' },
+  draft:     { dot: 'bg-yellow-400', text: 'text-yellow-400', border: 'border-yellow-600', bg: 'bg-yellow-950/30' },
+  ended:     { dot: 'bg-gray-400',   text: 'text-gray-400',   border: 'border-gray-600',   bg: 'bg-gray-900/30' },
+  cancelled: { dot: 'bg-red-400',    text: 'text-red-400',    border: 'border-red-700',    bg: 'bg-red-950/30' },
+}
 
+export const StatusBadge = ({ text, status = 'active' }: BadgeProps) => {
+  const s = statusStyles[status]
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 ${s.border} ${s.bg}`}
+      aria-label={`Status: ${text}`}
+    >
+      <span className={`inline-block h-2 w-2 rounded-full ${s.dot}`} />
+      <span className={`text-sm ${s.text}`}>{text}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

  Closes #235
  Closes #236
  Closes #237
  Closes #238

### Changes

**#235 — Quick-action panel (dashboard hero)**
- New `QuickActions` component with 3 keyboard-accessible buttons: Create Event, Manage Tickets, View Analytics
- Visually distinct section between the CTA row and the stats grid; all buttons have keyboard-accessible focus states

**#236 — StatusBadge across manage-events**
- `StatusBadge` refactored with 4 variants: `active`, `draft`, `ended`, `cancelled`
- Each variant has distinct Tailwind colour tokens and an `aria-label`
- `manage/page.tsx` replaced with a proper events-list table that renders `StatusBadge` in the Status column for every row

**#237 — Unit tests for Card & StatusBadge**
- New test file `src/__tests__/dashboard-components.test.tsx`
- Covers `Card`, `CardHeader` (with/without optional subtitle), `StatDisplay`, and all 4 `StatusBadge` variants
- Snapshot tests for each variant; aria-label assertions
- All 44 tests pass (`npm test`)

**#238 — Recent-activity feed**
- New `RecentActivity` component with skeleton loading state, up to 10 timestamped entries, and a View all link
- Entry types: ticket sold, event published, verification scan — each with a distinct icon and colour
- Mounted below the stats grid on the organizer dashboard

### Testing
```
Test Files  6 passed (6)
Tests       44 passed (44)
Snapshots   4 written
```