### PR TITLE
feat(analytics): add real-time check-in counter with polling (FE-094)

### DIFF
--- a/src/__tests__/useCheckInCounter.test.ts
+++ b/src/__tests__/useCheckInCounter.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCheckInCounter } from "../hooks/useCheckInCounter";
+
+const POLL_MS = 15_000;
+
+const makeOkFetch = (data: object) =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => data,
+  } as Response);
+
+const makeErrFetch = () =>
+  vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({}),
+  } as Response);
+
+describe("useCheckInCounter", () => {
+  beforeEach(() => {
+    // Only fake setInterval/clearInterval — leave Promise/microtask queue real
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("fetches immediately on mount when isLive=true", async () => {
+    vi.stubGlobal("fetch", makeOkFetch({ checkInCount: 42, totalCapacity: 500 }));
+
+    const { result } = renderHook(() => useCheckInCounter("evt-1", true));
+
+    // Let the async fetch resolve
+    await act(async () => {});
+
+    expect(result.current.checkInCount).toBe(42);
+    expect(result.current.totalCapacity).toBe(500);
+    expect(result.current.lastUpdated).toBeInstanceOf(Date);
+  });
+
+  it("does NOT fetch on mount when isLive=false", async () => {
+    const fetchMock = makeOkFetch({ checkInCount: 0, totalCapacity: 0 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useCheckInCounter("evt-2", false));
+
+    act(() => { vi.advanceTimersByTime(POLL_MS * 3); });
+    await act(async () => {});
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("polls every 15 s while isLive=true", async () => {
+    const fetchMock = makeOkFetch({ checkInCount: 10, totalCapacity: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useCheckInCounter("evt-3", true));
+
+    // Initial fetch
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Tick 1
+    act(() => { vi.advanceTimersByTime(POLL_MS); });
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Tick 2
+    act(() => { vi.advanceTimersByTime(POLL_MS); });
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops polling when isLive transitions false", async () => {
+    const fetchMock = makeOkFetch({ checkInCount: 5, totalCapacity: 100 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = renderHook(
+      ({ live }) => useCheckInCounter("evt-4", live),
+      { initialProps: { live: true } }
+    );
+
+    await act(async () => {});
+    const callsBefore = fetchMock.mock.calls.length;
+
+    // Event ends
+    rerender({ live: false });
+
+    act(() => { vi.advanceTimersByTime(POLL_MS * 3); });
+    await act(async () => {});
+
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("clears interval on unmount", async () => {
+    vi.stubGlobal("fetch", makeOkFetch({ checkInCount: 0, totalCapacity: 300 }));
+    const clearSpy = vi.spyOn(global, "clearInterval");
+
+    const { unmount } = renderHook(() => useCheckInCounter("evt-5", true));
+
+    await act(async () => {});
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it("exposes an error when the API call fails", async () => {
+    vi.stubGlobal("fetch", makeErrFetch());
+
+    const { result } = renderHook(() => useCheckInCounter("evt-6", true));
+
+    await act(async () => {});
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.checkInCount).toBeNull();
+  });
+
+  it("manual refresh re-fetches immediately", async () => {
+    const fetchMock = makeOkFetch({ checkInCount: 77, totalCapacity: 400 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useCheckInCounter("evt-7", true));
+
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => { result.current.refresh(); });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/dashboard/LiveCheckInCounter.tsx
+++ b/src/components/dashboard/LiveCheckInCounter.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useCheckInCounter } from "@/hooks/useCheckInCounter";
+import { cn } from "@/lib/cn";
+import { RefreshCw, Users, Wifi, WifiOff } from "lucide-react";
+
+interface LiveCheckInCounterProps {
+  eventId: string;
+  isLive: boolean;
+  className?: string;
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function AttendanceBar({
+  checkInCount,
+  totalCapacity,
+}: {
+  checkInCount: number;
+  totalCapacity: number;
+}) {
+  const pct = Math.min(100, Math.round((checkInCount / totalCapacity) * 100));
+  const colour =
+    pct >= 90 ? "bg-red-500" : pct >= 70 ? "bg-amber-500" : "bg-emerald-500";
+
+  return (
+    <div className="mt-4 space-y-1">
+      <div className="flex justify-between text-xs text-gray-500">
+        <span>{checkInCount.toLocaleString()} checked in</span>
+        <span>{pct}% capacity</span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-gray-200 overflow-hidden">
+        <div
+          className={cn("h-full rounded-full transition-all duration-700", colour)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-right text-xs text-gray-400">
+        of {totalCapacity.toLocaleString()} total capacity
+      </p>
+    </div>
+  );
+}
+
+export function LiveCheckInCounter({
+  eventId,
+  isLive,
+  className,
+}: LiveCheckInCounterProps) {
+  const { checkInCount, totalCapacity, lastUpdated, loading, error, refresh } =
+    useCheckInCounter(eventId, isLive);
+
+  return (
+    <div
+      className={cn(
+        "relative rounded-2xl border border-gray-200 bg-white p-6 shadow-sm",
+        className
+      )}
+      role="region"
+      aria-label="Live check-in counter"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="h-5 w-5 text-[#013237]" />
+          <h2 className="text-sm font-semibold text-[#013237] uppercase tracking-wide">
+            Live Check-ins
+          </h2>
+        </div>
+
+        {/* Live / offline badge */}
+        {isLive ? (
+          <span className="flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
+            {/* Pulsing dot */}
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+            </span>
+            LIVE
+          </span>
+        ) : (
+          <span className="flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-500">
+            <WifiOff className="h-3 w-3" />
+            Event ended
+          </span>
+        )}
+      </div>
+
+      {/* Main counter */}
+      <div className="mt-5 flex items-end gap-3">
+        {checkInCount !== null ? (
+          <span
+            className={cn(
+              "text-5xl font-bold tabular-nums text-[#013237] transition-opacity duration-300",
+              loading && "opacity-60"
+            )}
+          >
+            {checkInCount.toLocaleString()}
+          </span>
+        ) : (
+          <span className="text-5xl font-bold text-gray-300">—</span>
+        )}
+
+        {/* Spinning indicator while fetching */}
+        {loading && (
+          <Wifi className="mb-1.5 h-5 w-5 animate-pulse text-emerald-500" />
+        )}
+      </div>
+
+      {/* Capacity bar */}
+      {checkInCount !== null && totalCapacity !== null && totalCapacity > 0 && (
+        <AttendanceBar
+          checkInCount={checkInCount}
+          totalCapacity={totalCapacity}
+        />
+      )}
+
+      {/* Error message */}
+      {error && (
+        <p
+          role="alert"
+          className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600"
+        >
+          ⚠ {error} — data may be stale.
+        </p>
+      )}
+
+      {/* Footer: last updated + manual refresh */}
+      <div className="mt-4 flex items-center justify-between border-t border-gray-100 pt-3">
+        <p className="text-xs text-gray-400">
+          {lastUpdated
+            ? `Updated ${formatTime(lastUpdated)}`
+            : isLive
+              ? "Fetching…"
+              : "Polling paused"}
+        </p>
+
+        <button
+          onClick={refresh}
+          disabled={loading || !isLive}
+          aria-label="Manually refresh check-in count"
+          className={cn(
+            "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+            isLive
+              ? "bg-[#013237] text-white hover:bg-[#024a50] active:scale-95"
+              : "cursor-not-allowed bg-gray-100 text-gray-400"
+          )}
+        >
+          <RefreshCw
+            className={cn("h-3.5 w-3.5", loading && "animate-spin")}
+          />
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default LiveCheckInCounter;

--- a/src/features/analyics/page.tsx
+++ b/src/features/analyics/page.tsx
@@ -1,7 +1,57 @@
-import React from "react";
+"use client";
 
-function page() {
-  return <div>Analytics page - event owner stats, ticket sales, etc. later wave!</div>;
+import { LiveCheckInCounter } from "@/components/dashboard/LiveCheckInCounter";
+import { useParams } from "next/navigation";
+
+/**
+ * Determine if an event is "live" based on its start/end datetimes.
+ * Replace with a real status field from your API if available.
+ */
+function isEventLive(startIso: string, endIso: string): boolean {
+  const now = Date.now();
+  return (
+    now >= new Date(startIso).getTime() && now <= new Date(endIso).getTime()
+  );
 }
 
-export default page;
+const DEMO_EVENT = {
+  id: "demo-123",
+  name: "Afrobeats Night Lagos",
+  startIso: new Date(Date.now() - 30 * 60 * 1000).toISOString(), // started 30 min ago
+  endIso: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(), // ends in 3 h
+};
+
+export default function AnalyticsLivePage() {
+  const params = useParams<{ eventId?: string }>();
+  const eventId = params?.eventId ?? DEMO_EVENT.id;
+
+  const live = isEventLive(DEMO_EVENT.startIso, DEMO_EVENT.endIso);
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-8 px-4 py-10">
+      <header>
+        <h1 className="text-2xl font-bold text-[#013237]">
+          Analytics — {DEMO_EVENT.name}
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Real-time attendance and ticket metrics for organizers.
+        </p>
+      </header>
+
+      <section aria-labelledby="checkin-section">
+        <h2 id="checkin-section" className="sr-only">
+          Check-in counter
+        </h2>
+        <LiveCheckInCounter
+          eventId={eventId}
+          isLive={live}
+          className="max-w-sm"
+        />
+      </section>
+
+      <section className="rounded-2xl border border-dashed border-gray-300 p-8 text-center text-sm text-gray-400">
+        Additional analytics widgets (revenue chart, ticket mix, …) — later wave
+      </section>
+    </main>
+  );
+}

--- a/src/hooks/useCheckInCounter.ts
+++ b/src/hooks/useCheckInCounter.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const POLL_INTERVAL_MS = 15_000;
+
+export interface CheckInCounterState {
+  checkInCount: number | null;
+  totalCapacity: number | null;
+  lastUpdated: Date | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+async function fetchCheckInCount(
+  eventId: string
+): Promise<{ checkInCount: number; totalCapacity: number }> {
+  const res = await fetch(`/api/events/${eventId}/check-ins/count`);
+  if (!res.ok) throw new Error(`Server responded ${res.status}`);
+  return res.json();
+}
+
+export function useCheckInCounter(
+  eventId: string,
+  isLive: boolean
+): CheckInCounterState {
+  const [checkInCount, setCheckInCount] = useState<number | null>(null);
+  const [totalCapacity, setTotalCapacity] = useState<number | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep a ref so the interval callback always has the latest `isLive` value
+  const isLiveRef = useRef(isLive);
+  isLiveRef.current = isLive;
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!isLiveRef.current) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchCheckInCount(eventId);
+      setCheckInCount(data.checkInCount);
+      setTotalCapacity(data.totalCapacity);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch count");
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    fetchData(); // immediate first fetch
+    intervalRef.current = setInterval(fetchData, POLL_INTERVAL_MS);
+  }, [fetchData, stopPolling]);
+
+  useEffect(() => {
+    if (isLive) {
+      startPolling();
+    } else {
+      stopPolling();
+    }
+    return stopPolling; // cleanup on unmount or dependency change
+  }, [isLive, startPolling, stopPolling]);
+
+  return {
+    checkInCount,
+    totalCapacity,
+    lastUpdated,
+    loading,
+    error,
+    refresh: fetchData,
+  };
+}


### PR DESCRIPTION
Adds a polling-based live check-in counter to the organizer analytics view.

- `useCheckInCounter` hook polls `/api/events/:id/check-ins/count` every 15s while `isLive` is true, stops on unmount or event end
- `LiveCheckInCounter` component shows count, capacity bar, last-updated timestamp, and pulsing LIVE badge
- Manual refresh button available as fallback
- 7 unit tests covering polling, cleanup, error, and manual refresh

Closes #223