### PR TITLE
Event Creation Form — Gallery Limit, Location Autocomplete, Online Mode & E2E Test

### DIFF
--- a/src/__tests__/event-creation-e2e.test.tsx
+++ b/src/__tests__/event-creation-e2e.test.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// ---- vi.mock factories must not reference outer scope, so use vi.hoisted ----
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/events/create",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) =>
+    React.createElement("a", { href }, children),
+}));
+
+vi.mock("framer-motion", () => {
+  const proxy = new Proxy(
+    {},
+    {
+      get:
+        (_t, tag: string) =>
+        ({
+          children,
+          ...rest
+        }: React.HTMLAttributes<HTMLElement> & {
+          children?: React.ReactNode;
+        }) =>
+          React.createElement(
+            tag === "button" ? "button" : "div",
+            rest,
+            children,
+          ),
+    },
+  );
+  return {
+    motion: proxy,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+// Mock the ImageUpload component so the E2E test doesn't have to deal with
+// File-validation / dimension checks. Clicking the rendered button triggers
+// onChange with a fake image File so the cover-image requirement is met.
+vi.mock("@/components/events/ui/ImageUpload", () => ({
+  default: ({
+    onChange,
+  }: {
+    onChange: (file: File | null) => void;
+  }) =>
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        "data-testid": "mock-image-upload",
+        onClick: () =>
+          onChange(
+            new File(["fake-image-bytes"], "cover.png", { type: "image/png" }),
+          ),
+      },
+      "Upload",
+    ),
+}));
+
+// Avoid hitting the real Nominatim service when typing into the address combobox.
+vi.mock("@/lib/locationSearch", () => ({
+  searchLocations: vi.fn().mockResolvedValue([]),
+}));
+
+import CreateEventPage from "@/app/(protected)/events/create/page";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  pushMock.mockClear();
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ id: "evt_123", slug: "stellar-summit-2026" }),
+  });
+  // @ts-expect-error - jsdom fetch override
+  global.fetch = fetchMock;
+  localStorage.clear();
+});
+
+describe("Event Creation – end-to-end flow", () => {
+  it("walks every section with valid data, submits the FormData payload, and redirects to /events/manage", async () => {
+    const { container } = render(<CreateEventPage />);
+
+    // ----- Section 1: Basic Information -----
+    fireEvent.change(
+      screen.getByPlaceholderText("Give your event a catchy title"),
+      { target: { value: "Stellar Summit 2026" } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText("Describe your event in details"),
+      {
+        target: {
+          value: "An on-chain ticketing showcase for VeriTix builders.",
+        },
+      },
+    );
+    // Set the cover image via the mocked uploader (uploaders[0] is the cover slot)
+    const uploaders = screen.getAllByTestId("mock-image-upload");
+    fireEvent.click(uploaders[0]);
+
+    // ----- Section 2: Date & Time -----
+    const dateInputs = container.querySelectorAll('input[type="date"]');
+    const timeInputs = container.querySelectorAll('input[type="time"]');
+    fireEvent.change(dateInputs[0], { target: { value: "2026-12-01" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-12-02" } });
+    fireEvent.change(timeInputs[0], { target: { value: "10:00" } });
+    fireEvent.change(timeInputs[1], { target: { value: "18:00" } });
+
+    // ----- Section 3: Location (default = physical) -----
+    fireEvent.change(screen.getByPlaceholderText("Enter Venue name"), {
+      target: { value: "Stellar Hall" },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText("Start typing an address…"),
+      { target: { value: "123 Main Street" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("City"), {
+      target: { value: "Lagos" },
+    });
+
+    // ----- Section 4: Tickets -----
+    fireEvent.change(
+      screen.getByPlaceholderText("e.g. VIP, General admission"),
+      { target: { value: "General Admission" } },
+    );
+    const quantityInput = container.querySelector(
+      'input[type="number"][min="0"]',
+    ) as HTMLInputElement;
+    fireEvent.change(quantityInput, { target: { value: "100" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. 0.05"), {
+      target: { value: "0.1" },
+    });
+
+    // ----- Section 5: Blockchain (default = ethereum) -----
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "e.g. 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+      ),
+      { target: { value: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed" } },
+    );
+
+    // ----- Submit -----
+    fireEvent.click(screen.getByRole("button", { name: /create event/i }));
+
+    // The submit handler issues a single POST to /api/events with FormData.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [
+      string,
+      { method: string; body: FormData },
+    ];
+    expect(url).toBe("/api/events");
+    expect(options.method).toBe("POST");
+    expect(options.body).toBeInstanceOf(FormData);
+
+    const body = options.body;
+
+    // --- Basic Information ---
+    expect(body.get("title")).toBe("Stellar Summit 2026");
+    expect(body.get("description")).toBe(
+      "An on-chain ticketing showcase for VeriTix builders.",
+    );
+    expect(body.get("coverImage")).toBeInstanceOf(File);
+
+    // --- Date & Time ---
+    expect(body.get("startDate")).toBe("2026-12-01");
+    expect(body.get("endDate")).toBe("2026-12-02");
+    expect(body.get("startTime")).toBe("10:00");
+    expect(body.get("endTime")).toBe("18:00");
+
+    // --- Location ---
+    expect(body.get("eventType")).toBe("physical");
+    expect(body.get("venueName")).toBe("Stellar Hall");
+    expect(body.get("address")).toBe("123 Main Street");
+    expect(body.get("city")).toBe("Lagos");
+
+    // --- Tickets (the submit util appends array entries under the same key) ---
+    expect(body.getAll("tickets").length).toBeGreaterThanOrEqual(1);
+
+    // --- Blockchain ---
+    expect(body.get("blockchainNetwork")).toBe("ethereum");
+    expect(body.get("treasuryAddress")).toBe(
+      "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+    );
+    expect(body.get("creatorRoyalty")).toBe("3");
+
+    // --- Redirect to manage-events on success ---
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/events/manage");
+    });
+  });
+});

--- a/src/app/(protected)/events/create/page.tsx
+++ b/src/app/(protected)/events/create/page.tsx
@@ -39,6 +39,8 @@ export interface EventFormData {
   city: string;
   state: string;
   zipCode: string;
+  latitude: number | null;
+  longitude: number | null;
 
   // Ticket Information
   tickets: Array<{
@@ -72,6 +74,8 @@ const initialFormData: EventFormData = {
   city: "",
   state: "",
   zipCode: "",
+  latitude: null,
+  longitude: null,
   tickets: [
     {
       name: "",

--- a/src/app/(protected)/events/create/page.tsx
+++ b/src/app/(protected)/events/create/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import BasicInformation from "@/components/events/create/BasicInformation";
 import DateAndTime from "@/components/events/create/DateAndTime";
 import Location from "@/components/events/create/Location";
@@ -95,6 +96,7 @@ const initialFormData: EventFormData = {
 };
 
 export default function CreateEventPage() {
+  const router = useRouter();
   const [formData, setFormData] = useState<EventFormData>(initialFormData);
   const [errors, setErrors] = useState<CreateEventFormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -167,6 +169,7 @@ export default function CreateEventPage() {
       await submitCreateEvent(formData);
       setIsDirty(false);
       localStorage.removeItem(DRAFT_KEY);
+      router.push("/events/manage");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Failed to create event.";
       setErrors({ _form: msg });

--- a/src/app/(protected)/events/create/page.tsx
+++ b/src/app/(protected)/events/create/page.tsx
@@ -41,6 +41,7 @@ export interface EventFormData {
   zipCode: string;
   latitude: number | null;
   longitude: number | null;
+  streamingUrl: string;
 
   // Ticket Information
   tickets: Array<{
@@ -76,6 +77,7 @@ const initialFormData: EventFormData = {
   zipCode: "",
   latitude: null,
   longitude: null,
+  streamingUrl: "",
   tickets: [
     {
       name: "",

--- a/src/components/events/create/BasicInformation.tsx
+++ b/src/components/events/create/BasicInformation.tsx
@@ -4,6 +4,11 @@ import React from "react";
 import { EventFormData } from "@/app/(protected)/events/create/page";
 import ImageUpload from "../ui/ImageUpload";
 import type { CreateEventFormErrors } from "@/lib/createEventValidation";
+import {
+  MAX_GALLERY_IMAGES,
+  getGalleryLimitMessage,
+  isGalleryFull,
+} from "@/lib/galleryLimit";
 
 interface BasicInformationProps {
   formData: EventFormData;
@@ -86,18 +91,27 @@ export default function BasicInformation({
 
         {/* Event Gallery */}
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-2">
-            Event Gallery (Optional)
-          </label>
+          <div className="flex items-center justify-between mb-2">
+            <label className="block text-sm font-medium text-gray-300">
+              Event Gallery (Optional)
+            </label>
+            <span
+              className="text-xs text-gray-400"
+              aria-live="polite"
+              data-testid="gallery-counter"
+            >
+              {formData.gallery.length} / {MAX_GALLERY_IMAGES} images uploaded
+            </span>
+          </div>
           <div className="grid grid-cols-3 gap-4">
-            {[0, 1, 2].map((index) => (
+            {formData.gallery.map((file, index) => (
               <ImageUpload
                 key={index}
-                file={formData.gallery[index] || null}
-                onChange={(file) => {
+                file={file}
+                onChange={(next) => {
                   const newGallery = [...formData.gallery];
-                  if (file) {
-                    newGallery[index] = file;
+                  if (next) {
+                    newGallery[index] = next;
                   } else {
                     newGallery.splice(index, 1);
                   }
@@ -107,7 +121,30 @@ export default function BasicInformation({
                 size="small"
               />
             ))}
+            {!isGalleryFull(formData.gallery.length) && (
+              <ImageUpload
+                key={`add-${formData.gallery.length}`}
+                file={null}
+                onChange={(next) => {
+                  if (!next) return;
+                  updateFormData({
+                    gallery: [...formData.gallery, next],
+                  });
+                }}
+                aspectRatio="square"
+                size="small"
+              />
+            )}
           </div>
+          {isGalleryFull(formData.gallery.length) && (
+            <p
+              className="mt-2 text-xs text-amber-400"
+              role="status"
+              data-testid="gallery-limit-message"
+            >
+              {getGalleryLimitMessage()} Remove an image to upload another.
+            </p>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/events/create/Location.tsx
+++ b/src/components/events/create/Location.tsx
@@ -14,6 +14,8 @@ interface LocationProps {
 
 export default function Location({ formData, updateFormData, errors = {} }: LocationProps) {
   const needsVenue = formData.eventType !== "online";
+  const showStreamingUrl =
+    formData.eventType === "online" || formData.eventType === "hybrid";
 
   // ---- Address autocomplete state ----
   const [suggestions, setSuggestions] = useState<LocationResult[]>([]);
@@ -169,29 +171,32 @@ export default function Location({ formData, updateFormData, errors = {} }: Loca
         </div>
 
         {/* Venue Name */}
-        <div>
-          <label className="block text-sm font-medium text-gray-300 mb-2">
-            Venue Name {needsVenue && <span className="text-red-400">*</span>}
-          </label>
-          <input
-            type="text"
-            value={formData.venueName}
-            onChange={(e) => updateFormData({ venueName: e.target.value })}
-            placeholder="Enter Venue name"
-            aria-invalid={!!errors.venueName}
-            className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.venueName ? "border-red-500" : "border-gray-700"}`}
-          />
-          {errors.venueName && <p role="alert" className="mt-1 text-xs text-red-400">{errors.venueName}</p>}
-        </div>
+        {needsVenue && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">
+              Venue Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={formData.venueName}
+              onChange={(e) => updateFormData({ venueName: e.target.value })}
+              placeholder="Enter Venue name"
+              aria-invalid={!!errors.venueName}
+              className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.venueName ? "border-red-500" : "border-gray-700"}`}
+            />
+            {errors.venueName && <p role="alert" className="mt-1 text-xs text-red-400">{errors.venueName}</p>}
+          </div>
+        )}
 
         {/* Address */}
-        <div>
-          <label
-            htmlFor="event-address"
-            className="block text-sm font-medium text-gray-300 mb-2"
-          >
-            Address {needsVenue && <span className="text-red-400">*</span>}
-          </label>
+        {needsVenue && (
+          <div>
+            <label
+              htmlFor="event-address"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              Address <span className="text-red-400">*</span>
+            </label>
           <div className="relative" ref={wrapperRef}>
             <input
               id="event-address"
@@ -261,80 +266,118 @@ export default function Location({ formData, updateFormData, errors = {} }: Loca
               {errors.address}
             </p>
           )}
-        </div>
+          </div>
+        )}
 
         {/* City, State, Zip Code */}
-        <div className="grid grid-cols-3 gap-4">
+        {needsVenue && (
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                City <span className="text-red-400">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.city}
+                onChange={(e) => updateFormData({ city: e.target.value })}
+                placeholder="City"
+                aria-invalid={!!errors.city}
+                className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.city ? "border-red-500" : "border-gray-700"}`}
+              />
+              {errors.city && <p role="alert" className="mt-1 text-xs text-red-400">{errors.city}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                State
+              </label>
+              <input
+                type="text"
+                value={formData.state}
+                onChange={(e) => updateFormData({ state: e.target.value })}
+                placeholder="State"
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                Zip Code
+              </label>
+              <input
+                type="text"
+                value={formData.zipCode}
+                onChange={(e) => updateFormData({ zipCode: e.target.value })}
+                placeholder="Zip Code"
+                className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Streaming URL — online & hybrid only */}
+        {showStreamingUrl && (
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
-              City {needsVenue && <span className="text-red-400">*</span>}
+            <label
+              htmlFor="event-streaming-url"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              Streaming URL <span className="text-red-400">*</span>
             </label>
             <input
-              type="text"
-              value={formData.city}
-              onChange={(e) => updateFormData({ city: e.target.value })}
-              placeholder="City"
-              aria-invalid={!!errors.city}
-              className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.city ? "border-red-500" : "border-gray-700"}`}
+              id="event-streaming-url"
+              type="url"
+              inputMode="url"
+              value={formData.streamingUrl}
+              onChange={(e) => updateFormData({ streamingUrl: e.target.value })}
+              placeholder="https://zoom.us/j/… or https://meet.google.com/…"
+              aria-invalid={!!errors.streamingUrl}
+              aria-describedby={
+                errors.streamingUrl ? "error-streaming-url" : "hint-streaming-url"
+              }
+              className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.streamingUrl ? "border-red-500" : "border-gray-700"}`}
             />
-            {errors.city && <p role="alert" className="mt-1 text-xs text-red-400">{errors.city}</p>}
+            <p id="hint-streaming-url" className="mt-1 text-xs text-gray-500">
+              Provide a link attendees will use to join the event (Zoom, Meet, YouTube Live, etc.).
+            </p>
+            {errors.streamingUrl && (
+              <p id="error-streaming-url" role="alert" className="mt-1 text-xs text-red-400">
+                {errors.streamingUrl}
+              </p>
+            )}
           </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
-              State
-            </label>
-            <input
-              type="text"
-              value={formData.state}
-              onChange={(e) => updateFormData({ state: e.target.value })}
-              placeholder="State"
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
-              Zip Code
-            </label>
-            <input
-              type="text"
-              value={formData.zipCode}
-              onChange={(e) => updateFormData({ zipCode: e.target.value })}
-              placeholder="Zip Code"
-              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-            />
-          </div>
-        </div>
+        )}
 
         {/* Map Placeholder */}
-        <div>
-          <label className="block text-sm font-medium text-gray-300 mb-2">
-            Map
-          </label>
-          <div className="w-full h-64 bg-gray-800 border-2 border-dashed border-gray-700 rounded-lg flex flex-col items-center justify-center">
-            <svg
-              className="w-12 h-12 text-gray-600 mb-2"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-            <p className="text-gray-500 text-sm">
-              Map integration will appear here
-            </p>
+        {needsVenue && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">
+              Map
+            </label>
+            <div className="w-full h-64 bg-gray-800 border-2 border-dashed border-gray-700 rounded-lg flex flex-col items-center justify-center">
+              <svg
+                className="w-12 h-12 text-gray-600 mb-2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              <p className="text-gray-500 text-sm">
+                Map integration will appear here
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/src/components/events/create/Location.tsx
+++ b/src/components/events/create/Location.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { EventFormData } from "@/app/(protected)/events/create/page";
 import RadioButton from "../ui/RadioButton";
 import type { CreateEventFormErrors } from "@/lib/createEventValidation";
+import { searchLocations, type LocationResult } from "@/lib/locationSearch";
 
 interface LocationProps {
   formData: EventFormData;
@@ -13,6 +14,111 @@ interface LocationProps {
 
 export default function Location({ formData, updateFormData, errors = {} }: LocationProps) {
   const needsVenue = formData.eventType !== "online";
+
+  // ---- Address autocomplete state ----
+  const [suggestions, setSuggestions] = useState<LocationResult[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const skipNextSearch = useRef(false);
+
+  // Debounced search whenever the address text changes
+  useEffect(() => {
+    if (skipNextSearch.current) {
+      // Skip the next search after a suggestion is selected programmatically
+      skipNextSearch.current = false;
+      return;
+    }
+    const query = formData.address.trim();
+    if (query.length < 3) {
+      setSuggestions([]);
+      setSearched(false);
+      setIsSearching(false);
+      return;
+    }
+    let cancelled = false;
+    setIsSearching(true);
+    const handle = setTimeout(async () => {
+      try {
+        const results = await searchLocations(query);
+        if (cancelled) return;
+        setSuggestions(results);
+        setSearched(true);
+        setActiveIdx(-1);
+      } catch {
+        if (!cancelled) {
+          setSuggestions([]);
+          setSearched(true);
+        }
+      } finally {
+        if (!cancelled) setIsSearching(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [formData.address]);
+
+  // Click-outside dismissal
+  useEffect(() => {
+    const handleDocClick = (e: MouseEvent) => {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) setIsOpen(false);
+    };
+    document.addEventListener("mousedown", handleDocClick);
+    return () => document.removeEventListener("mousedown", handleDocClick);
+  }, []);
+
+  const handleSelectSuggestion = (s: LocationResult) => {
+    skipNextSearch.current = true;
+    updateFormData({
+      address: s.address.street || s.displayName,
+      city: s.address.city || formData.city,
+      latitude: s.lat,
+      longitude: s.lng,
+    });
+    setIsOpen(false);
+    setSuggestions([]);
+    setActiveIdx(-1);
+  };
+
+  const handleAddressChange = (value: string) => {
+    // Manual entry — clear previously-selected coordinates so they don't
+    // misrepresent the freshly-typed address.
+    updateFormData({
+      address: value,
+      latitude: null,
+      longitude: null,
+    });
+    setIsOpen(true);
+  };
+
+  const handleAddressKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen || suggestions.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => (i + 1) % suggestions.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (e.key === "Enter" && activeIdx >= 0) {
+      e.preventDefault();
+      handleSelectSuggestion(suggestions[activeIdx]);
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+    }
+  };
+
+  const showNoResultsHint =
+    isOpen &&
+    !isSearching &&
+    searched &&
+    suggestions.length === 0 &&
+    formData.address.trim().length >= 3;
+
   return (
     <section className="bg-gray-900 rounded-xl p-6 border border-gray-800">
       <div className="flex items-center gap-3 mb-6">
@@ -80,16 +186,81 @@ export default function Location({ formData, updateFormData, errors = {} }: Loca
 
         {/* Address */}
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-2">
-            Address
+          <label
+            htmlFor="event-address"
+            className="block text-sm font-medium text-gray-300 mb-2"
+          >
+            Address {needsVenue && <span className="text-red-400">*</span>}
           </label>
-          <input
-            type="text"
-            value={formData.address}
-            onChange={(e) => updateFormData({ address: e.target.value })}
-            placeholder="Enter full address"
-            className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-          />
+          <div className="relative" ref={wrapperRef}>
+            <input
+              id="event-address"
+              type="text"
+              value={formData.address}
+              onChange={(e) => handleAddressChange(e.target.value)}
+              onFocus={() => {
+                if (suggestions.length > 0 || formData.address.trim().length >= 3) {
+                  setIsOpen(true);
+                }
+              }}
+              onKeyDown={handleAddressKeyDown}
+              placeholder="Start typing an address…"
+              autoComplete="off"
+              role="combobox"
+              aria-expanded={isOpen}
+              aria-autocomplete="list"
+              aria-controls="address-suggestions"
+              aria-activedescendant={
+                activeIdx >= 0 ? `address-suggestion-${activeIdx}` : undefined
+              }
+              aria-invalid={!!errors.address}
+              aria-describedby={errors.address ? "error-address" : undefined}
+              className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent ${errors.address ? "border-red-500" : "border-gray-700"}`}
+            />
+            {isSearching && (
+              <span
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400"
+                aria-live="polite"
+              >
+                Searching…
+              </span>
+            )}
+            {isOpen && suggestions.length > 0 && (
+              <ul
+                id="address-suggestions"
+                role="listbox"
+                className="absolute z-20 left-0 right-0 mt-1 max-h-64 overflow-y-auto bg-gray-900 border border-gray-700 rounded-lg shadow-lg"
+              >
+                {suggestions.map((s, idx) => (
+                  <li
+                    key={`${s.lat},${s.lng},${idx}`}
+                    id={`address-suggestion-${idx}`}
+                    role="option"
+                    aria-selected={idx === activeIdx}
+                    onMouseDown={(e) => {
+                      // Use mouseDown so we beat the input blur
+                      e.preventDefault();
+                      handleSelectSuggestion(s);
+                    }}
+                    onMouseEnter={() => setActiveIdx(idx)}
+                    className={`px-4 py-2 text-sm text-white cursor-pointer ${idx === activeIdx ? "bg-blue-700" : "hover:bg-gray-800"}`}
+                  >
+                    {s.displayName}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {showNoResultsHint && (
+              <p className="mt-1 text-xs text-gray-400">
+                No matches found — you can keep typing the address manually.
+              </p>
+            )}
+          </div>
+          {errors.address && (
+            <p id="error-address" role="alert" className="mt-1 text-xs text-red-400">
+              {errors.address}
+            </p>
+          )}
         </div>
 
         {/* City, State, Zip Code */}

--- a/src/lib/createEventValidation.ts
+++ b/src/lib/createEventValidation.ts
@@ -36,6 +36,8 @@ export const createEventSchema = z
     city: z.string().optional(),
     state: z.string().optional(),
     zipCode: z.string().optional(),
+    latitude: z.number().nullable().optional(),
+    longitude: z.number().nullable().optional(),
 
     // Tickets
     tickets: z.array(ticketSchema).min(1, "At least one ticket type is required"),
@@ -86,6 +88,13 @@ export const createEventSchema = z
           code: z.ZodIssueCode.custom,
           message: "Venue name is required for physical/hybrid events",
           path: ["venueName"],
+        });
+      }
+      if (!data.address?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Address is required for physical/hybrid events",
+          path: ["address"],
         });
       }
       if (!data.city?.trim()) {

--- a/src/lib/createEventValidation.ts
+++ b/src/lib/createEventValidation.ts
@@ -38,6 +38,7 @@ export const createEventSchema = z
     zipCode: z.string().optional(),
     latitude: z.number().nullable().optional(),
     longitude: z.number().nullable().optional(),
+    streamingUrl: z.string().optional(),
 
     // Tickets
     tickets: z.array(ticketSchema).min(1, "At least one ticket type is required"),
@@ -105,6 +106,27 @@ export const createEventSchema = z
         });
       }
     }
+
+    // Streaming URL is required for online/hybrid events and must be a valid URL.
+    if (data.eventType === "online" || data.eventType === "hybrid") {
+      const url = data.streamingUrl?.trim() ?? "";
+      if (!url) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Streaming URL is required for online events",
+          path: ["streamingUrl"],
+        });
+      } else {
+        const parsed = z.string().url().safeParse(url);
+        if (!parsed.success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Streaming URL must be a valid URL (e.g. https://example.com)",
+            path: ["streamingUrl"],
+          });
+        }
+      }
+    }
   });
 
 export type CreateEventFormErrors = Partial<Record<string, string>>;
@@ -125,7 +147,7 @@ export function parseCreateEventErrors(
 export function sectionForField(field: string): string {
   if (["title", "description", "coverImage"].includes(field)) return "Basic Information";
   if (["startDate", "startTime", "endDate", "endTime"].includes(field)) return "Date & Time";
-  if (["venueName", "address", "city", "state", "zipCode"].includes(field)) return "Location";
+  if (["venueName", "address", "city", "state", "zipCode", "streamingUrl"].includes(field)) return "Location";
   if (field.startsWith("tickets")) return "Ticket Information";
   if (["blockchainNetwork", "treasuryAddress", "creatorRoyalty"].includes(field)) return "Blockchain Setting";
   return "General";
@@ -135,7 +157,7 @@ export function sectionForField(field: string): string {
 export function sectionIdForField(field: string): string {
   if (["title", "description", "coverImage"].includes(field)) return "section-basic";
   if (["startDate", "startTime", "endDate", "endTime"].includes(field)) return "section-datetime";
-  if (["venueName", "address", "city", "state", "zipCode"].includes(field)) return "section-location";
+  if (["venueName", "address", "city", "state", "zipCode", "streamingUrl"].includes(field)) return "section-location";
   if (field.startsWith("tickets")) return "section-tickets";
   if (["blockchainNetwork", "treasuryAddress", "creatorRoyalty"].includes(field)) return "section-blockchain";
   return "";


### PR DESCRIPTION
This PR Hardens the multi-step Create Event flow with three UX/feature improvements and locks them in with a full end-to-end test.

1. Enforce gallery image upload limit (Task 1)
Wired [galleryLimit.ts](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/lib/galleryLimit.ts) into [BasicInformation.tsx](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/components/events/create/BasicInformation.tsx).
Added an X / Y images uploaded counter with aria-live="polite".
Replaced fixed 3-slot grid with a dynamic list: one tile per uploaded image plus a single trailing "+ Add" tile that's only rendered when the limit isn't reached.
Inline amber role="status" message appears when the cap is hit; removing an image re-enables uploads automatically.
closes #259 

Address autocomplete on the Location step (Task 2)
Extended EventFormData with latitude / longitude so coordinates persist.
Replaced plain Address input in [Location.tsx](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/components/events/create/Location.tsx) with an accessible combobox driven by [searchLocations](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/lib/locationSearch.ts):
300 ms debounced query, gated to ≥3 chars.
Full keyboard support (ArrowUp/Down/Enter/Escape) with aria-activedescendant.
Click-outside dismissal, "Searching…" indicator, and a no-matches hint that lets the user keep typing freely.
Selecting a suggestion populates address, city, latitude, longitude in one update.
Added address as required for physical/hybrid events in [createEventValidation.ts](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/lib/createEventValidation.ts) so submission is blocked when missing.
closes #260 

Online event mode with streaming URL (Task 3)
Added streamingUrl to EventFormData (auto-persisted to localStorage like the rest of the draft).
Zod schema now requires streamingUrl for online/hybrid events and validates it via z.string().url().
In [Location.tsx](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/components/events/create/Location.tsx), all physical-only blocks (Venue, Address, City/State/Zip, Map) are now wrapped in {needsVenue && (…)} so they're fully unmounted in online mode — not just disabled.
A new "Streaming URL" field renders for online and hybrid modes with helper text and full a11y wiring.
Toggle state (eventType) is preserved across reloads via the existing draft-persistence pipeline.
closes #261 

End-to-end test for the full creation flow (Task 4)
Added router.push("/events/manage") to the success branch of handleCreateEvent in [page.tsx](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/app/(protected)/events/create/page.tsx).
New test [event-creation-e2e.test.tsx](file:///C:/Users/a-abdulkareem/Documents/SISTER/veritix-web/src/__tests__/event-creation-e2e.test.tsx) walks every section — Basic Info → Date & Time → Location → Tickets → Blockchain — with valid input, then asserts:
fetch was called once with POST /api/events and a FormData body.
The payload contains the expected title, description, cover image File, dates/times, location fields, ticket entries, blockchain network, treasury address, and creator royalty.
On success, router.push is called with /events/manage.
closes #262 