### PR TITLE
 Organizer Event Management Enhancements

### DIFF
--- a/src/app/(protected)/events/manage/[eventId]/page.tsx
+++ b/src/app/(protected)/events/manage/[eventId]/page.tsx
@@ -2,6 +2,10 @@
 
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { toast } from "react-toastify";
+import { Modal } from "@/components/ui";
+import { performEventAction } from "@/lib/eventActions";
 
 interface Event {
   id: string;
@@ -13,6 +17,8 @@ export default function ManageEventPage() {
   const { eventId } = useParams<{ eventId: string }>();
   const [event, setEvent] = useState<Event | null>(null);
   const [loading, setLoading] = useState(true);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (!eventId) return;
@@ -22,13 +28,106 @@ export default function ManageEventPage() {
       .finally(() => setLoading(false));
   }, [eventId]);
 
+  const handleConfirmCancel = async () => {
+    if (!event || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await performEventAction(event.id, "cancel");
+      if (!result.success) {
+        toast.error(result.message);
+        return;
+      }
+      toast.success("Event cancelled. Refunds and notifications have been queued.");
+      setEvent({ ...event, status: "cancelled" });
+      setConfirmOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to cancel event.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   if (loading) return <p>Loading event...</p>;
   if (!event) return <p>Event not found.</p>;
 
+  const isCancelled = event.status === "cancelled";
+
   return (
-    <main>
-      <h1>Manage: {event.name}</h1>
-      <p>Status: {event.status}</p>
+    <main className="min-h-screen bg-[#101428] px-4 py-10 text-white">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-bold">Manage: {event.name}</h1>
+        <p className="mt-2 text-[#21D4FF]/80">Status: {event.status}</p>
+
+        {/* Danger zone — Cancel Event */}
+        <section className="mt-10 rounded-xl border border-red-700/50 bg-red-950/20 p-6">
+          <h2 className="text-lg font-semibold text-red-300">Danger zone</h2>
+          <p className="mt-1 text-sm text-red-200/80">
+            Cancelling this event is irreversible. All ticket holders will be
+            refunded and notified automatically.
+          </p>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            disabled={isCancelled}
+            className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isCancelled ? "Event already cancelled" : "Cancel Event"}
+          </button>
+        </section>
+      </div>
+
+      {/* Themed cancellation confirmation modal */}
+      <Modal
+        open={confirmOpen}
+        onClose={() => {
+          if (!submitting) setConfirmOpen(false);
+        }}
+        title="Cancel this event?"
+        description="This action is permanent and cannot be undone."
+        size="md"
+      >
+        <div className="space-y-4">
+          <div className="flex items-start gap-3 rounded-lg border border-red-700/40 bg-red-950/30 p-4">
+            <AlertTriangle className="mt-0.5 shrink-0 text-red-400" size={20} aria-hidden="true" />
+            <div className="text-sm text-red-100/90">
+              <p className="font-semibold text-red-200">
+                Cancelling &ldquo;{event.name}&rdquo; will:
+              </p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-red-100/80">
+                <li>Trigger refunds for every ticket already sold.</li>
+                <li>Notify all attendees by email and in-app notification.</li>
+                <li>Mark the event as cancelled on the public events page.</li>
+                <li>Prevent any further ticket sales for this event.</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={() => setConfirmOpen(false)}
+              disabled={submitting}
+              className="rounded-lg border border-white/20 bg-transparent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Keep event
+            </button>
+            <button
+              type="button"
+              onClick={handleConfirmCancel}
+              disabled={submitting}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {submitting && (
+                <span
+                  className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
+                  aria-hidden="true"
+                />
+              )}
+              {submitting ? "Cancelling…" : "Confirm Cancellation"}
+            </button>
+          </div>
+        </div>
+      </Modal>
     </main>
   );
 }

--- a/src/app/(protected)/events/manage/[eventId]/page.tsx
+++ b/src/app/(protected)/events/manage/[eventId]/page.tsx
@@ -6,6 +6,8 @@ import { AlertTriangle } from "lucide-react";
 import { toast } from "react-toastify";
 import { Modal } from "@/components/ui";
 import { performEventAction } from "@/lib/eventActions";
+import TabSelector from "@/components/TabSelector";
+import AttendeesTab from "@/components/events/manage/AttendeesTab";
 
 interface Event {
   id: string;
@@ -13,12 +15,16 @@ interface Event {
   status: string;
 }
 
+const TABS = ["Overview", "Attendees"] as const;
+type Tab = (typeof TABS)[number];
+
 export default function ManageEventPage() {
   const { eventId } = useParams<{ eventId: string }>();
   const [event, setEvent] = useState<Event | null>(null);
   const [loading, setLoading] = useState(true);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>("Overview");
 
   useEffect(() => {
     if (!eventId) return;
@@ -54,26 +60,44 @@ export default function ManageEventPage() {
 
   return (
     <main className="min-h-screen bg-[#101428] px-4 py-10 text-white">
-      <div className="mx-auto max-w-3xl">
+      <div className="mx-auto max-w-5xl">
         <h1 className="text-3xl font-bold">Manage: {event.name}</h1>
         <p className="mt-2 text-[#21D4FF]/80">Status: {event.status}</p>
 
-        {/* Danger zone — Cancel Event */}
-        <section className="mt-10 rounded-xl border border-red-700/50 bg-red-950/20 p-6">
-          <h2 className="text-lg font-semibold text-red-300">Danger zone</h2>
-          <p className="mt-1 text-sm text-red-200/80">
-            Cancelling this event is irreversible. All ticket holders will be
-            refunded and notified automatically.
-          </p>
-          <button
-            type="button"
-            onClick={() => setConfirmOpen(true)}
-            disabled={isCancelled}
-            className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+        <TabSelector<Tab>
+          tabs={TABS as unknown as Tab[]}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          className="!px-0"
+        />
+
+        {activeTab === "Overview" && (
+          <section
+            role="tabpanel"
+            aria-label="Overview"
+            className="mt-6 rounded-xl border border-red-700/50 bg-red-950/20 p-6"
           >
-            {isCancelled ? "Event already cancelled" : "Cancel Event"}
-          </button>
-        </section>
+            <h2 className="text-lg font-semibold text-red-300">Danger zone</h2>
+            <p className="mt-1 text-sm text-red-200/80">
+              Cancelling this event is irreversible. All ticket holders will be
+              refunded and notified automatically.
+            </p>
+            <button
+              type="button"
+              onClick={() => setConfirmOpen(true)}
+              disabled={isCancelled}
+              className="mt-4 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isCancelled ? "Event already cancelled" : "Cancel Event"}
+            </button>
+          </section>
+        )}
+
+        {activeTab === "Attendees" && (
+          <div role="tabpanel" aria-label="Attendees" className="mt-6">
+            <AttendeesTab eventId={event.id} />
+          </div>
+        )}
       </div>
 
       {/* Themed cancellation confirmation modal */}

--- a/src/app/(protected)/events/manage/page.tsx
+++ b/src/app/(protected)/events/manage/page.tsx
@@ -1,9 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { MoreVertical } from 'lucide-react'
 import { Modal } from '@/components/ui'
 import { StatusBadge, EventStatus } from '@/components/dashboard/StatusBadge'
+import {
+  prepareDuplicateDraft,
+  type DuplicableEventData,
+} from '@/lib/duplicateEvent'
 
 interface ManagedEvent {
   id: string
@@ -13,16 +19,112 @@ interface ManagedEvent {
   ticketsSold: number
   totalTickets: number
   status: EventStatus
+  /**
+   * Full source data used when duplicating this event into the create-event form.
+   * Stored alongside the row so the kebab menu's Duplicate action can pre-fill
+   * ticket types, pricing, treasury address, etc.
+   */
+  source: DuplicableEventData
 }
 
 type BulkAction = 'cancel' | 'duplicate'
 
 const INITIAL_EVENTS: ManagedEvent[] = [
-  { id: '1', name: 'Summer Music Festival',  date: '2026-07-15', location: 'Central Park, NY',          ticketsSold: 342, totalTickets: 500, status: 'active' },
-  { id: '2', name: 'Tech Conference 2026',   date: '2026-08-20', location: 'Convention Center, SF',     ticketsSold: 156, totalTickets: 200, status: 'active' },
-  { id: '3', name: 'Lagos Art Fair',         date: '2026-06-01', location: 'Eko Hotel, Lagos',          ticketsSold: 80,  totalTickets: 300, status: 'draft' },
-  { id: '4', name: 'Afrobeats Night Out',    date: '2025-12-31', location: 'O2 Arena, London',          ticketsSold: 600, totalTickets: 600, status: 'ended' },
-  { id: '5', name: 'Web3 Summit',            date: '2026-03-10', location: 'Dubai World Trade Centre',  ticketsSold: 0,   totalTickets: 400, status: 'cancelled' },
+  {
+    id: '1', name: 'Summer Music Festival', date: '2026-07-15', location: 'Central Park, NY',
+    ticketsSold: 342, totalTickets: 500, status: 'active',
+    source: {
+      title: 'Summer Music Festival',
+      description: 'A weekend of live music in Central Park.',
+      startDate: '2026-07-15', endDate: '2026-07-17',
+      startTime: '14:00', endTime: '23:00',
+      eventType: 'physical',
+      venueName: 'Central Park Great Lawn', address: 'Central Park', city: 'New York', state: 'NY', zipCode: '10024',
+      tickets: [
+        { name: 'General Admission', quantity: 400, price: '75', description: 'Standing access', transferable: true, resellable: true, resellPriceLimit: '110' },
+        { name: 'VIP', quantity: 100, price: '200', description: 'Front-stage + lounge', transferable: true, resellable: false, resellPriceLimit: '' },
+      ],
+      blockchainNetwork: 'ethereum',
+      treasuryAddress: '0xA1B2C3d4E5F60718293a4b5C6D7E8f9A0b1C2D3e',
+      creatorRoyalty: 5,
+    },
+  },
+  {
+    id: '2', name: 'Tech Conference 2026', date: '2026-08-20', location: 'Convention Center, SF',
+    ticketsSold: 156, totalTickets: 200, status: 'active',
+    source: {
+      title: 'Tech Conference 2026',
+      description: 'Annual gathering of builders shipping on Stellar.',
+      startDate: '2026-08-20', endDate: '2026-08-21',
+      startTime: '09:00', endTime: '18:00',
+      eventType: 'hybrid',
+      venueName: 'Moscone West', address: '800 Howard St', city: 'San Francisco', state: 'CA', zipCode: '94103',
+      tickets: [
+        { name: 'Standard', quantity: 150, price: '120', description: 'Talks + expo', transferable: true, resellable: false, resellPriceLimit: '' },
+        { name: 'Workshop Pass', quantity: 50, price: '250', description: 'Hands-on labs', transferable: false, resellable: false, resellPriceLimit: '' },
+      ],
+      blockchainNetwork: 'polygon',
+      treasuryAddress: '0xB2C3D4E5F60718293a4b5C6D7E8f9A0b1C2D3e4F',
+      creatorRoyalty: 3,
+    },
+  },
+  {
+    id: '3', name: 'Lagos Art Fair', date: '2026-06-01', location: 'Eko Hotel, Lagos',
+    ticketsSold: 80, totalTickets: 300, status: 'draft',
+    source: {
+      title: 'Lagos Art Fair',
+      description: 'Contemporary West African art showcase.',
+      startDate: '2026-06-01', endDate: '2026-06-03',
+      startTime: '10:00', endTime: '20:00',
+      eventType: 'physical',
+      venueName: 'Eko Hotel & Suites', address: 'Plot 1415 Adetokunbo Ademola St', city: 'Lagos', state: 'Lagos', zipCode: '101241',
+      tickets: [
+        { name: 'Day Pass', quantity: 250, price: '15', description: 'Single-day access', transferable: true, resellable: true, resellPriceLimit: '25' },
+        { name: 'Weekend Pass', quantity: 50, price: '40', description: 'All three days', transferable: true, resellable: false, resellPriceLimit: '' },
+      ],
+      blockchainNetwork: 'ethereum',
+      treasuryAddress: '0xC3D4E5F60718293a4b5C6D7E8f9A0b1C2D3e4F50',
+      creatorRoyalty: 2,
+    },
+  },
+  {
+    id: '4', name: 'Afrobeats Night Out', date: '2025-12-31', location: 'O2 Arena, London',
+    ticketsSold: 600, totalTickets: 600, status: 'ended',
+    source: {
+      title: 'Afrobeats Night Out',
+      description: 'Year-end Afrobeats showcase featuring top artists.',
+      startDate: '2025-12-31', endDate: '2026-01-01',
+      startTime: '20:00', endTime: '02:00',
+      eventType: 'physical',
+      venueName: 'The O2 Arena', address: 'Peninsula Square', city: 'London', state: '', zipCode: 'SE10 0DX',
+      tickets: [
+        { name: 'Standing', quantity: 500, price: '60', description: 'General floor', transferable: true, resellable: true, resellPriceLimit: '90' },
+        { name: 'Seated Premium', quantity: 100, price: '120', description: 'Reserved seating', transferable: true, resellable: false, resellPriceLimit: '' },
+      ],
+      blockchainNetwork: 'polygon',
+      treasuryAddress: '0xD4E5F60718293a4b5C6D7E8f9A0b1C2D3e4F5061',
+      creatorRoyalty: 4,
+    },
+  },
+  {
+    id: '5', name: 'Web3 Summit', date: '2026-03-10', location: 'Dubai World Trade Centre',
+    ticketsSold: 0, totalTickets: 400, status: 'cancelled',
+    source: {
+      title: 'Web3 Summit',
+      description: 'Cross-chain protocols and ecosystem updates.',
+      startDate: '2026-03-10', endDate: '2026-03-12',
+      startTime: '09:00', endTime: '17:00',
+      eventType: 'physical',
+      venueName: 'Dubai World Trade Centre', address: 'Sheikh Zayed Rd', city: 'Dubai', state: '', zipCode: '00000',
+      tickets: [
+        { name: 'Attendee', quantity: 350, price: '180', description: 'Full summit access', transferable: true, resellable: false, resellPriceLimit: '' },
+        { name: 'Investor', quantity: 50, price: '500', description: 'Includes private dinner', transferable: false, resellable: false, resellPriceLimit: '' },
+      ],
+      blockchainNetwork: 'solana',
+      treasuryAddress: '0xE5F60718293a4b5C6D7E8f9A0b1C2D3e4F506172',
+      creatorRoyalty: 3,
+    },
+  },
 ]
 
 const STATUS_LABELS: Record<EventStatus, string> = {
@@ -33,10 +135,38 @@ const STATUS_LABELS: Record<EventStatus, string> = {
 }
 
 export default function ManageEventsPage() {
+  const router = useRouter()
   const [events, setEvents] = useState<ManagedEvent[]>(INITIAL_EVENTS)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [bulkAction, setBulkAction] = useState<'' | BulkAction>('')
   const [confirmOpen, setConfirmOpen] = useState(false)
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close kebab menu on outside click or Escape
+  useEffect(() => {
+    if (!openMenuId) return
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpenMenuId(null)
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenuId(null)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [openMenuId])
+
+  const handleDuplicateRow = (event: ManagedEvent) => {
+    setOpenMenuId(null)
+    prepareDuplicateDraft(event.source)
+    router.push('/events/create')
+  }
 
   const selectedCount = selectedIds.size
   const allSelected = events.length > 0 && selectedCount === events.length
@@ -199,12 +329,48 @@ export default function ManageEventsPage() {
                       <StatusBadge status={event.status} text={STATUS_LABELS[event.status]} />
                     </td>
                     <td className="px-6 py-4">
-                      <Link
-                        href={`/events/manage/${event.id}`}
-                        className="text-[#4D21FF] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+                      <div
+                        ref={openMenuId === event.id ? menuRef : undefined}
+                        className="relative inline-block text-left"
                       >
-                        Manage →
-                      </Link>
+                        <button
+                          type="button"
+                          aria-label={`Open actions for ${event.name}`}
+                          aria-haspopup="menu"
+                          aria-expanded={openMenuId === event.id}
+                          onClick={() =>
+                            setOpenMenuId((prev) => (prev === event.id ? null : event.id))
+                          }
+                          className="rounded-md p-1.5 text-[#21D4FF]/80 transition-colors hover:bg-[#4D21FF]/20 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+                        >
+                          <MoreVertical size={16} />
+                        </button>
+
+                        {openMenuId === event.id && (
+                          <div
+                            role="menu"
+                            aria-label={`${event.name} actions`}
+                            className="absolute right-0 z-20 mt-1 w-44 overflow-hidden rounded-lg border border-[#4D21FF]/40 bg-[#0b1025] shadow-[0_20px_40px_rgba(10,16,40,0.7)]"
+                          >
+                            <Link
+                              role="menuitem"
+                              href={`/events/manage/${event.id}`}
+                              onClick={() => setOpenMenuId(null)}
+                              className="block px-4 py-2 text-sm text-white transition-colors hover:bg-[#4D21FF]/30 focus-visible:bg-[#4D21FF]/30 focus-visible:outline-none"
+                            >
+                              Manage
+                            </Link>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => handleDuplicateRow(event)}
+                              className="block w-full px-4 py-2 text-left text-sm text-white transition-colors hover:bg-[#4D21FF]/30 focus-visible:bg-[#4D21FF]/30 focus-visible:outline-none"
+                            >
+                              Duplicate
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </td>
                   </tr>
                 )

--- a/src/app/(protected)/events/manage/page.tsx
+++ b/src/app/(protected)/events/manage/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { Modal } from '@/components/ui'
 import { StatusBadge, EventStatus } from '@/components/dashboard/StatusBadge'
 
 interface ManagedEvent {
@@ -13,7 +15,9 @@ interface ManagedEvent {
   status: EventStatus
 }
 
-const MOCK_EVENTS: ManagedEvent[] = [
+type BulkAction = 'cancel' | 'duplicate'
+
+const INITIAL_EVENTS: ManagedEvent[] = [
   { id: '1', name: 'Summer Music Festival',  date: '2026-07-15', location: 'Central Park, NY',          ticketsSold: 342, totalTickets: 500, status: 'active' },
   { id: '2', name: 'Tech Conference 2026',   date: '2026-08-20', location: 'Convention Center, SF',     ticketsSold: 156, totalTickets: 200, status: 'active' },
   { id: '3', name: 'Lagos Art Fair',         date: '2026-06-01', location: 'Eko Hotel, Lagos',          ticketsSold: 80,  totalTickets: 300, status: 'draft' },
@@ -29,6 +33,69 @@ const STATUS_LABELS: Record<EventStatus, string> = {
 }
 
 export default function ManageEventsPage() {
+  const [events, setEvents] = useState<ManagedEvent[]>(INITIAL_EVENTS)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [bulkAction, setBulkAction] = useState<'' | BulkAction>('')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const selectedCount = selectedIds.size
+  const allSelected = events.length > 0 && selectedCount === events.length
+  const someSelected = selectedCount > 0 && !allSelected
+
+  const selectedEvents = useMemo(
+    () => events.filter((e) => selectedIds.has(e.id)),
+    [events, selectedIds],
+  )
+
+  const toggleRow = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    setSelectedIds((prev) =>
+      prev.size === events.length ? new Set() : new Set(events.map((e) => e.id)),
+    )
+  }
+
+  const handleApply = () => {
+    if (!bulkAction || selectedCount === 0) return
+    // Cancel is irreversible — require explicit confirmation.
+    if (bulkAction === 'cancel') {
+      setConfirmOpen(true)
+      return
+    }
+    runBulkAction(bulkAction)
+  }
+
+  const runBulkAction = (action: BulkAction) => {
+    if (action === 'cancel') {
+      setEvents((prev) =>
+        prev.map((e) => (selectedIds.has(e.id) ? { ...e, status: 'cancelled' } : e)),
+      )
+    } else if (action === 'duplicate') {
+      setEvents((prev) => {
+        const copies: ManagedEvent[] = prev
+          .filter((e) => selectedIds.has(e.id))
+          .map((e) => ({
+            ...e,
+            id: `${e.id}-copy-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+            name: `${e.name} (Copy)`,
+            ticketsSold: 0,
+            status: 'draft',
+          }))
+        return [...prev, ...copies]
+      })
+    }
+    setSelectedIds(new Set())
+    setBulkAction('')
+    setConfirmOpen(false)
+  }
+
   return (
     <div className="min-h-screen bg-[#101428] py-10 px-4">
       <div className="mx-auto max-w-6xl">
@@ -42,10 +109,59 @@ export default function ManageEventsPage() {
           </Link>
         </div>
 
+        {/* Bulk-action toolbar */}
+        <div
+          className="mb-4 flex flex-wrap items-center gap-3 rounded-xl border border-[#4D21FF]/30 bg-[#000625] px-4 py-3"
+          role="toolbar"
+          aria-label="Bulk actions"
+        >
+          <span className="text-sm text-[#21D4FF]/80" aria-live="polite">
+            {selectedCount > 0
+              ? `${selectedCount} selected`
+              : 'Select rows to enable bulk actions'}
+          </span>
+
+          <label htmlFor="bulk-action" className="sr-only">
+            Bulk action
+          </label>
+          <select
+            id="bulk-action"
+            value={bulkAction}
+            onChange={(e) => setBulkAction(e.target.value as '' | BulkAction)}
+            disabled={selectedCount === 0}
+            className="ml-auto rounded-lg border border-[#4D21FF]/40 bg-[#101428] px-3 py-2 text-sm text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <option value="">Bulk action…</option>
+            <option value="cancel">Cancel</option>
+            <option value="duplicate">Duplicate</option>
+          </select>
+
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={selectedCount === 0 || !bulkAction}
+            className="rounded-lg bg-[linear-gradient(135deg,#4D21FF_0%,#21D4FF_100%)] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Apply
+          </button>
+        </div>
+
         <div className="overflow-x-auto rounded-xl border border-[#4D21FF]/30 bg-[#000625]">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-[#4D21FF]/30 text-left text-xs uppercase tracking-wider text-[#21D4FF]">
+                <th className="px-4 py-4">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all events"
+                    className="h-4 w-4 cursor-pointer accent-[#4D21FF]"
+                    checked={allSelected}
+                    ref={(el) => {
+                      if (el) el.indeterminate = someSelected
+                    }}
+                    onChange={toggleAll}
+                  />
+                </th>
                 <th className="px-6 py-4">Event</th>
                 <th className="px-6 py-4">Date</th>
                 <th className="px-6 py-4">Location</th>
@@ -55,33 +171,79 @@ export default function ManageEventsPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-[#4D21FF]/20">
-              {MOCK_EVENTS.map((event) => (
-                <tr key={event.id} className="transition-colors hover:bg-[#4D21FF]/5">
-                  <td className="px-6 py-4 font-medium text-white">{event.name}</td>
-                  <td className="px-6 py-4 text-[#21D4FF]/80">
-                    {new Date(event.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                  </td>
-                  <td className="px-6 py-4 text-[#21D4FF]/80">{event.location}</td>
-                  <td className="px-6 py-4 text-[#21D4FF]/80">
-                    {event.ticketsSold} / {event.totalTickets}
-                  </td>
-                  <td className="px-6 py-4">
-                    <StatusBadge status={event.status} text={STATUS_LABELS[event.status]} />
-                  </td>
-                  <td className="px-6 py-4">
-                    <Link
-                      href={`/events/manage/${event.id}`}
-                      className="text-[#4D21FF] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
-                    >
-                      Manage →
-                    </Link>
-                  </td>
-                </tr>
-              ))}
+              {events.map((event) => {
+                const checked = selectedIds.has(event.id)
+                return (
+                  <tr
+                    key={event.id}
+                    className={`transition-colors hover:bg-[#4D21FF]/5 ${checked ? 'bg-[#4D21FF]/10' : ''}`}
+                  >
+                    <td className="px-4 py-4">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select ${event.name}`}
+                        className="h-4 w-4 cursor-pointer accent-[#4D21FF]"
+                        checked={checked}
+                        onChange={() => toggleRow(event.id)}
+                      />
+                    </td>
+                    <td className="px-6 py-4 font-medium text-white">{event.name}</td>
+                    <td className="px-6 py-4 text-[#21D4FF]/80">
+                      {new Date(event.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                    </td>
+                    <td className="px-6 py-4 text-[#21D4FF]/80">{event.location}</td>
+                    <td className="px-6 py-4 text-[#21D4FF]/80">
+                      {event.ticketsSold} / {event.totalTickets}
+                    </td>
+                    <td className="px-6 py-4">
+                      <StatusBadge status={event.status} text={STATUS_LABELS[event.status]} />
+                    </td>
+                    <td className="px-6 py-4">
+                      <Link
+                        href={`/events/manage/${event.id}`}
+                        className="text-[#4D21FF] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+                      >
+                        Manage →
+                      </Link>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
       </div>
+
+      {/* Confirmation dialog for irreversible bulk actions */}
+      <Modal
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        title="Cancel selected events?"
+        description={`This will cancel ${selectedCount} event${selectedCount === 1 ? '' : 's'}. This action cannot be undone.`}
+        size="sm"
+      >
+        <ul className="mb-5 max-h-40 list-disc overflow-auto rounded-lg border border-white/10 bg-white/5 px-6 py-3 text-sm text-white/80">
+          {selectedEvents.map((e) => (
+            <li key={e.id}>{e.name}</li>
+          ))}
+        </ul>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(false)}
+            className="rounded-lg border border-white/20 bg-transparent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+          >
+            Keep events
+          </button>
+          <button
+            type="button"
+            onClick={() => runBulkAction('cancel')}
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          >
+            Yes, cancel events
+          </button>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/components/events/manage/AttendeesTab.tsx
+++ b/src/components/events/manage/AttendeesTab.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Download, Search } from "lucide-react";
+import { toast } from "react-toastify";
+import {
+  type Attendee,
+  checkInAttendee,
+  exportAttendeesCSV,
+  fetchEventAttendees,
+} from "@/lib/attendeeManagement";
+
+interface AttendeesTabProps {
+  eventId: string;
+}
+
+const PAGE_SIZE = 10;
+
+export default function AttendeesTab({ eventId }: AttendeesTabProps) {
+  const [attendees, setAttendees] = useState<Attendee[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [checkingInId, setCheckingInId] = useState<string | null>(null);
+
+  // Initial fetch
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchEventAttendees(eventId)
+      .then((data) => {
+        if (!cancelled) setAttendees(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load attendees.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId]);
+
+  // Filter by name or email (case-insensitive)
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return attendees;
+    return attendees.filter(
+      (a) =>
+        a.name.toLowerCase().includes(q) || a.email.toLowerCase().includes(q),
+    );
+  }, [attendees, search]);
+
+  // Reset to page 1 whenever the search narrows or widens the results
+  useEffect(() => {
+    setPage(1);
+  }, [search]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * PAGE_SIZE;
+  const pageRows = filtered.slice(pageStart, pageStart + PAGE_SIZE);
+
+  const handleCheckIn = async (attendee: Attendee) => {
+    if (attendee.checkedIn || checkingInId) return;
+    setCheckingInId(attendee.id);
+    try {
+      const result = await checkInAttendee(eventId, attendee.id);
+      if (!result.success) {
+        toast.error(result.message);
+        return;
+      }
+      setAttendees((prev) =>
+        prev.map((a) => (a.id === attendee.id ? { ...a, checkedIn: true } : a)),
+      );
+      toast.success(`Checked in ${attendee.name}.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Check-in failed.");
+    } finally {
+      setCheckingInId(null);
+    }
+  };
+
+  const handleExport = () => {
+    if (attendees.length === 0) {
+      toast.info("No attendees to export.");
+      return;
+    }
+    // Export everything currently loaded for this event (not just the filtered/paged view).
+    exportAttendeesCSV(attendees, eventId);
+  };
+
+  return (
+    <section className="space-y-4" aria-label="Attendees">
+      {/* Toolbar: search + export */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="relative block w-full sm:max-w-sm">
+          <span className="sr-only">Search attendees by name or email</span>
+          <Search
+            size={16}
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[#21D4FF]/70"
+          />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or email"
+            className="w-full rounded-lg border border-[#4D21FF]/40 bg-[#101428] py-2 pl-9 pr-3 text-sm text-white placeholder:text-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF]"
+          />
+        </label>
+
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={loading || attendees.length === 0}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#4D21FF]/40 bg-[#000625] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#4D21FF]/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Download size={16} aria-hidden="true" />
+          Export CSV
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-[#4D21FF]/30 bg-[#000625]">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[#4D21FF]/30 text-left text-xs uppercase tracking-wider text-[#21D4FF]">
+              <th scope="col" className="px-6 py-4">Name</th>
+              <th scope="col" className="px-6 py-4">Email</th>
+              <th scope="col" className="px-6 py-4">Ticket Type</th>
+              <th scope="col" className="px-6 py-4">Check-in</th>
+              <th scope="col" className="px-6 py-4">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#4D21FF]/20">
+            {loading ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-10 text-center text-[#21D4FF]/70">
+                  Loading attendees…
+                </td>
+              </tr>
+            ) : error ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-10 text-center text-red-400">
+                  {error}
+                </td>
+              </tr>
+            ) : pageRows.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-10 text-center text-white/60">
+                  {attendees.length === 0
+                    ? "No attendees yet."
+                    : "No attendees match your search."}
+                </td>
+              </tr>
+            ) : (
+              pageRows.map((a) => (
+                <tr key={a.id} className="transition-colors hover:bg-[#4D21FF]/5">
+                  <td className="px-6 py-4 font-medium text-white">{a.name}</td>
+                  <td className="px-6 py-4 text-[#21D4FF]/80">{a.email}</td>
+                  <td className="px-6 py-4 text-[#21D4FF]/80">{a.ticketType}</td>
+                  <td className="px-6 py-4">
+                    {a.checkedIn ? (
+                      <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-950/30 px-3 py-1 text-xs text-emerald-300">
+                        <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                        Checked in
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-white/70">
+                        <span className="h-2 w-2 rounded-full bg-white/40" />
+                        Pending
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-6 py-4">
+                    <button
+                      type="button"
+                      onClick={() => handleCheckIn(a)}
+                      disabled={a.checkedIn || checkingInId === a.id}
+                      className="rounded-md bg-[linear-gradient(135deg,#4D21FF_0%,#21D4FF_100%)] px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {a.checkedIn
+                        ? "Already in"
+                        : checkingInId === a.id
+                          ? "Checking…"
+                          : "Mark checked in"}
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {!loading && !error && filtered.length > 0 && (
+        <div className="flex flex-col items-center justify-between gap-2 text-sm text-white/70 sm:flex-row">
+          <span aria-live="polite">
+            Showing {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, filtered.length)} of{" "}
+            {filtered.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={safePage <= 1}
+              className="rounded-md border border-white/15 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <span aria-current="page">
+              Page {safePage} / {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={safePage >= totalPages}
+              className="rounded-md border border-white/15 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/attendeeManagement.ts
+++ b/src/lib/attendeeManagement.ts
@@ -16,6 +16,18 @@ export async function fetchEventAttendees(eventId: string): Promise<Attendee[]> 
   return res.json();
 }
 
+export async function checkInAttendee(
+  eventId: string,
+  attendeeId: string
+): Promise<{ success: boolean; message: string }> {
+  const res = await fetch(
+    `/api/events/${eventId}/attendees/${attendeeId}/check-in`,
+    { method: "POST" }
+  );
+  if (!res.ok) return { success: false, message: "Check-in failed. Please try again." };
+  return { success: true, message: "Attendee checked in." };
+}
+
 export function exportAttendeesCSV(attendees: Attendee[], eventId = "event"): void {
   const headers = ["Name", "Email", "Ticket Type", "Order ID", "Checked In", "Purchased At"];
   const rows = attendees.map((a) => [

--- a/src/lib/duplicateEvent.ts
+++ b/src/lib/duplicateEvent.ts
@@ -1,0 +1,37 @@
+// Helper for duplicating an event into the create-event form.
+// Persists the source event's data into localStorage under the same key the
+// create-event page reads from on mount, so navigating to `/events/create`
+// hydrates the form with the duplicated data.
+
+import type { EventFormData } from "@/app/(protected)/events/create/page";
+
+export const DRAFT_KEY = "veritix_event_draft";
+export const COPY_PREFIX = "Copy of ";
+
+// Subset of EventFormData that can be JSON-serialised
+// (File-backed fields like coverImage/gallery cannot be persisted).
+export type DuplicableEventData = Partial<
+  Omit<EventFormData, "coverImage" | "gallery">
+>;
+
+/**
+ * Stash the source event's data so the create-event page picks it up on mount.
+ * The title is prefixed with "Copy of " to make duplication explicit (and is
+ * not double-prefixed if the source already starts with the prefix).
+ */
+export function prepareDuplicateDraft(source: DuplicableEventData): void {
+  if (typeof window === "undefined") return;
+
+  const baseTitle = source.title?.trim() || "Untitled";
+  const title = baseTitle.startsWith(COPY_PREFIX)
+    ? baseTitle
+    : `${COPY_PREFIX}${baseTitle}`;
+
+  const draft: DuplicableEventData = { ...source, title };
+
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // localStorage may be unavailable (SSR / quota) — fail silently.
+  }
+}


### PR DESCRIPTION
This PR 

 # Bulk-action controls on the manage-events table

Organizers can now operate on multiple events at once.
Per-row + header checkboxes (with proper indeterminate "select all" state)
Sticky bulk-action toolbar with selection counter (aria-live="polite")
Bulk-action <select> (Cancel / Duplicate), enabled only when ≥ 1 row is selected
Irreversible Cancel routes through a themed confirmation modal listing the selected events
Duplicate runs immediately, cloning each selected row as a draft with (Copy) suffix and ticketsSold reset
closes #255 


# Per-row event duplication into the create-event form
Single-event duplication that pre-fills the full create-event form.
Replaced the "Manage →" link with an accessible kebab menu (MoreVertical, role="menu", outside-click + Esc to dismiss) containing Manage and Duplicate
New helper prepareDuplicateDraft() writes the source data to localStorage under the same key (veritix_event_draft) the create page reads on mount — no changes needed in the create page
Title auto-prefixed with 'Copy of ' (single-prefix-safe)
Source payload includes title, description, dates/times, event type, full address, ticket types (with pricing & resell rules), blockchain network, treasury address, and creator royalty
closes #256 


# Themed event cancellation confirmation modal
Replaces the bare browser confirm with an explicit, themed flow.
New "Danger zone" panel on the event detail page with a red Cancel Event button (auto-disabled when already cancelled)
Themed Modal listing four consequences: refunds triggered, attendees notified, public visibility updated, sales halted
Red Confirm Cancellation is the only proceed path; backdrop and Esc are blocked while the request is in flight
On confirm calls existing performEventAction(eventId, 'cancel'); success/error surfaced via react-toastify; local status updates to cancelled
closes #257 


# Attendee management tab on the event detail page
Surfaces the previously-unused attendeeManagement.ts utilities.
Added an Overview / Attendees TabSelector to the organizer event detail page
New AttendeesTab component with:
Table: Name, Email, Ticket Type, Check-in status
Search by name or email (live filter, resets to page 1)
Pagination (10/page) with "Showing x–y of N" live region + Previous/Next
Per-row Mark checked in button → calls new checkInAttendee() backend helper
Export CSV toolbar button (uses existing exportAttendeesCSV)
closes #258 