### PR TITLE
Add-Vitest-coverage-thresholds-to-the-CI-workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "veritix-web",
   "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "eslint",
-    "test": "vitest run",
-    "test:watch": "vitest"
-  },
+    "scripts": {
+      "dev": "next dev",
+      "build": "next build",
+      "start": "next start",
+      "lint": "eslint",
+      "test": "vitest run --coverage",
+      "test:watch": "vitest"
+    },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-slot": "^1.2.4",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/__tests__/setup.ts"],
+    coverage: {
+      reporter: ["text", "json", "html"],
+      thresholds: {
+        lines: 60,
+        branches: 60,
+        functions: 60,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Add Vitest Coverage Thresholds to CI Workflow

## Overview

This PR enhances the CI pipeline by enabling Vitest coverage reporting and enforcing minimum code coverage thresholds. This ensures that future changes maintain a baseline level of test coverage and helps prevent coverage regressions.

## Changes Made

* Added the `--coverage` flag to the Vitest test script used in CI.
* Configured coverage threshold enforcement in `vitest.config`.
* Enabled validation for:

  * Line coverage
  * Branch coverage
  * Function coverage
* Updated CI workflow to fail when coverage requirements are not met.

## Coverage Thresholds

The following minimum thresholds have been configured:

* **Lines:** 60%
* **Branches:** 60%
* **Functions:** 60%

These thresholds provide an initial quality baseline and can be increased as test coverage improves over time.

## Acceptance Criteria

* Vitest runs with coverage enabled in CI.
* CI fails if coverage falls below configured thresholds.
* Coverage thresholds are set to at least:

  * 60% line coverage
  * 60% branch coverage
  * 60% function coverage

## Benefits

* Prevents coverage regressions from being merged.
* Encourages stronger test coverage across the codebase.
* Provides automated quality checks as part of the CI process.
* Establishes a foundation for progressively improving test quality.
Closes #295 