### PR TITLE
Graph

### DIFF
--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { cn } from "../lib/cn";
+
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "danger";
+
+type ButtonSize = "sm" | "md" | "lg";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+};
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-gradient-to-r from-[#000625] via-[#0A1854] to-[#1E3A8A] shadow-[0px_4px_12px_0px_rgba(0,6,37,0.3)] text-white",
+  secondary:
+    "",
+  outline:
+    "border border-primary-black hover:bg-primary-black/10",
+  danger:
+    "bg-red-600 text-white hover:bg-red-700",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
+};
+
+export const Button = React.forwardRef<
+  HTMLButtonElement,
+  ButtonProps
+>(
+  (
+    {
+      variant = "primary",
+      size = "md",
+      isLoading = false,
+      leftIcon,
+      rightIcon,
+      disabled,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isDisabled = disabled || isLoading;
+
+    return (
+      <button
+        ref={ref}
+        disabled={isDisabled}
+        className={cn(
+          "inline-flex items-center justify-center gap-2 rounded-md font-medium transition",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          variantStyles[variant],
+          sizeStyles[size],
+          className
+        )}
+        {...props}
+      >
+        {isLoading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+
+        {!isLoading && leftIcon}
+        <span>{children}</span>
+        {!isLoading && rightIcon}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { cn } from "../lib/cn";
 
 type ButtonVariant =
-  | "primary"
-  | "secondary"
-  | "outline"
-  | "danger";
+  | "primarysolid"
+  | "secondarysolid"
+  | "outlinesolid"
+  | "dangersolid";
 
 type ButtonSize = "sm" | "md" | "lg";
 
@@ -18,13 +18,13 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const variantStyles: Record<ButtonVariant, string> = {
-  primary:
+  primarysolid:
     "bg-gradient-to-r from-[#000625] via-[#0A1854] to-[#1E3A8A] shadow-[0px_4px_12px_0px_rgba(0,6,37,0.3)] text-white",
-  secondary:
-    "",
-  outline:
+  secondarysolid:
+    "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  outlinesolid:
     "border border-primary-black hover:bg-primary-black/10",
-  danger:
+  dangersolid:
     "bg-red-600 text-white hover:bg-red-700",
 };
 
@@ -40,7 +40,7 @@ export const Button = React.forwardRef<
 >(
   (
     {
-      variant = "primary",
+      variant = "primarysolid",
       size = "md",
       isLoading = false,
       leftIcon,

--- a/src/mocks/event.ts
+++ b/src/mocks/event.ts
@@ -1,0 +1,124 @@
+import type { Event } from "@/types/event";
+
+/**
+ * Centralized mock event data for public and protected experiences.
+ * Replace these exports with API calls in the next wave.
+ */
+export const mockEvents: Event[] = [
+  {
+    id: "summer-dance-festival-1",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    dateEnd: "June 17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: true,
+    attendees: 1200,
+    description:
+      "Get ready to move at the ultimate Summer Dance Festival of 2024 — a high-energy celebration of music, culture, and community under the open sky. This unforgettable two-day experience brings together DJs, dance crews, and music lovers from around the world for a weekend packed with rhythm, beats, and unforgettable vibes.",
+    organizer: {
+      name: "Rhythm Nation Collective",
+      verified: true,
+      description: "Bringing immersive music experiences to life",
+    },
+    ticketOptions: [
+      {
+        name: "General Admission",
+        description: "Access to all stages and performances",
+        benefits: ["Entry to food courts and chill-out lounges"],
+        price: 0.08,
+        remaining: 200,
+        popular: true,
+      },
+      {
+        name: "VIP Pass",
+        description: "Everything in General Admission plus:",
+        benefits: [
+          "Priority entry",
+          "Exclusive access to VIP dance pit and lounges",
+          "Complimentary drink vouchers (x2)",
+        ],
+        price: 0.2,
+        remaining: 70,
+      },
+      {
+        name: "All-Access Experience",
+        description: "Everything in VIP Pass plus:",
+        benefits: [
+          "Backstage Tour & meet-and-greet with performers",
+          "Access to after-party events",
+          "Festival merch bundle (shirt + wristband + tote)",
+        ],
+        price: 0.4,
+        remaining: 30,
+      },
+    ],
+  },
+  {
+    id: "electronic-music-night-1",
+    name: "Electronic Music Night",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "music",
+    featured: false,
+    attendees: 800,
+    description:
+      "Experience the best electronic music under the stars. World-class DJs and incredible light shows await.",
+    organizer: {
+      name: "Beat Collective",
+      verified: true,
+      description: "Electronic music events since 2015",
+    },
+  },
+  {
+    id: "summer-dance-festival-2",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: false,
+    attendees: 1200,
+  },
+  {
+    id: "electronic-music-night-2",
+    name: "Electronic Music Night",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "music",
+    featured: false,
+    attendees: 800,
+  },
+];
+
+export const getEventsByCategory = (category: string): Event[] => {
+  if (category === "all") return mockEvents;
+  return mockEvents.filter((event) => event.category === category);
+};
+
+export const getFeaturedEvents = (): Event[] => {
+  return mockEvents.filter((event) => event.featured);
+};
+
+export const getEventById = (id: string): Event | undefined => {
+  return mockEvents.find((event) => event.id === id);
+};


### PR DESCRIPTION
 FE-181 Add Open Graph and Twitter card meta tags to public event pages
Description
Sharing a VeriTix event link on social media shows no preview card. Add dynamic Open Graph and Twitter Card meta tags to the event detail page using Next.js metadata API.

Acceptance Criteria

 og:title, og:description, og:image, and og:url are set per event.
 twitter:card, twitter:title, and twitter:image are set per event.
 Fallback values are used when optional event fields are absent.
 Tested with the Twitter Card Validator and Facebook Sharing Debugger.
 closes #301