### PR TITLE
Ban direct

### DIFF
--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { cn } from "../lib/cn";
+
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "danger";
+
+type ButtonSize = "sm" | "md" | "lg";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+};
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary:
+    "bg-gradient-to-r from-[#000625] via-[#0A1854] to-[#1E3A8A] shadow-[0px_4px_12px_0px_rgba(0,6,37,0.3)] text-white",
+  secondary:
+    "",
+  outline:
+    "border border-primary-black hover:bg-primary-black/10",
+  danger:
+    "bg-red-600 text-white hover:bg-red-700",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
+};
+
+export const Button = React.forwardRef<
+  HTMLButtonElement,
+  ButtonProps
+>(
+  (
+    {
+      variant = "primary",
+      size = "md",
+      isLoading = false,
+      leftIcon,
+      rightIcon,
+      disabled,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const isDisabled = disabled || isLoading;
+
+    return (
+      <button
+        ref={ref}
+        disabled={isDisabled}
+        className={cn(
+          "inline-flex items-center justify-center gap-2 rounded-md font-medium transition",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          variantStyles[variant],
+          sizeStyles[size],
+          className
+        )}
+        {...props}
+      >
+        {isLoading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+
+        {!isLoading && leftIcon}
+        <span>{children}</span>
+        {!isLoading && rightIcon}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/src/components/buttons.tsx
+++ b/src/components/buttons.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { cn } from "../lib/cn";
 
 type ButtonVariant =
-  | "primary"
-  | "secondary"
-  | "outline"
-  | "danger";
+  | "primarysolid"
+  | "secondarysolid"
+  | "outlinesolid"
+  | "dangersolid";
 
 type ButtonSize = "sm" | "md" | "lg";
 
@@ -18,13 +18,13 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const variantStyles: Record<ButtonVariant, string> = {
-  primary:
+  primarysolid:
     "bg-gradient-to-r from-[#000625] via-[#0A1854] to-[#1E3A8A] shadow-[0px_4px_12px_0px_rgba(0,6,37,0.3)] text-white",
-  secondary:
-    "",
-  outline:
+  secondarysolid:
+    "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  outlinesolid:
     "border border-primary-black hover:bg-primary-black/10",
-  danger:
+  dangersolid:
     "bg-red-600 text-white hover:bg-red-700",
 };
 
@@ -40,7 +40,7 @@ export const Button = React.forwardRef<
 >(
   (
     {
-      variant = "primary",
+      variant = "primarysolid",
       size = "md",
       isLoading = false,
       leftIcon,

--- a/src/mocks/event.ts
+++ b/src/mocks/event.ts
@@ -1,0 +1,124 @@
+import type { Event } from "@/types/event";
+
+/**
+ * Centralized mock event data for public and protected experiences.
+ * Replace these exports with API calls in the next wave.
+ */
+export const mockEvents: Event[] = [
+  {
+    id: "summer-dance-festival-1",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    dateEnd: "June 17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: true,
+    attendees: 1200,
+    description:
+      "Get ready to move at the ultimate Summer Dance Festival of 2024 — a high-energy celebration of music, culture, and community under the open sky. This unforgettable two-day experience brings together DJs, dance crews, and music lovers from around the world for a weekend packed with rhythm, beats, and unforgettable vibes.",
+    organizer: {
+      name: "Rhythm Nation Collective",
+      verified: true,
+      description: "Bringing immersive music experiences to life",
+    },
+    ticketOptions: [
+      {
+        name: "General Admission",
+        description: "Access to all stages and performances",
+        benefits: ["Entry to food courts and chill-out lounges"],
+        price: 0.08,
+        remaining: 200,
+        popular: true,
+      },
+      {
+        name: "VIP Pass",
+        description: "Everything in General Admission plus:",
+        benefits: [
+          "Priority entry",
+          "Exclusive access to VIP dance pit and lounges",
+          "Complimentary drink vouchers (x2)",
+        ],
+        price: 0.2,
+        remaining: 70,
+      },
+      {
+        name: "All-Access Experience",
+        description: "Everything in VIP Pass plus:",
+        benefits: [
+          "Backstage Tour & meet-and-greet with performers",
+          "Access to after-party events",
+          "Festival merch bundle (shirt + wristband + tote)",
+        ],
+        price: 0.4,
+        remaining: 30,
+      },
+    ],
+  },
+  {
+    id: "electronic-music-night-1",
+    name: "Electronic Music Night",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "music",
+    featured: false,
+    attendees: 800,
+    description:
+      "Experience the best electronic music under the stars. World-class DJs and incredible light shows await.",
+    organizer: {
+      name: "Beat Collective",
+      verified: true,
+      description: "Electronic music events since 2015",
+    },
+  },
+  {
+    id: "summer-dance-festival-2",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: false,
+    attendees: 1200,
+  },
+  {
+    id: "electronic-music-night-2",
+    name: "Electronic Music Night",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "music",
+    featured: false,
+    attendees: 800,
+  },
+];
+
+export const getEventsByCategory = (category: string): Event[] => {
+  if (category === "all") return mockEvents;
+  return mockEvents.filter((event) => event.category === category);
+};
+
+export const getFeaturedEvents = (): Event[] => {
+  return mockEvents.filter((event) => event.featured);
+};
+
+export const getEventById = (id: string): Event | undefined => {
+  return mockEvents.find((event) => event.id === id);
+};

--- a/src/mocks/event.ts
+++ b/src/mocks/event.ts
@@ -1,3 +1,128 @@
+// import type { Event } from "@/types/event";
+
+// /**
+//  * Centralized mock event data for public and protected experiences.
+//  * Replace these exports with API calls in the next wave.
+//  */
+// export const mockEvents: Event[] = [
+//   {
+//     id: "summer-dance-festival-2",
+//     name: "Summer Dance Festival",
+//     image: "/images/events/detail.png",
+//     date: "June 15-17, 2024",
+//     dateEnd: "June 17, 2024",
+//     time: "6:00 PM - 2:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.08 ETH",
+//     priceInEth: 0.08,
+//     category: "festival",
+//     featured: true,
+//     attendees: 1200,
+//     description:
+//       "Get ready to move at the ultimate Summer Dance Festival of 2024 — a high-energy celebration of music, culture, and community under the open sky. This unforgettable two-day experience brings together DJs, dance crews, and music lovers from around the world for a weekend packed with rhythm, beats, and unforgettable vibes.",
+//     organizer: {
+//       name: "Rhythm Nation Collective",
+//       verified: true,
+//       description: "Bringing immersive music experiences to life",
+//     },
+//     ticketOptions: [
+//       {
+//         name: "General Admission",
+//         description: "Access to all stages and performances",
+//         benefits: ["Entry to food courts and chill-out lounges"],
+//         price: 0.08,
+//         remaining: 200,
+//         popular: true,
+//       },
+//       {
+//         name: "VIP Pass",
+//         description: "Everything in General Admission plus:",
+//         benefits: [
+//           "Priority entry",
+//           "Exclusive access to VIP dance pit and lounges",
+//           "Complimentary drink vouchers (x2)",
+//         ],
+//         price: 0.2,
+//         remaining: 70,
+//       },
+//       {
+//         name: "All-Access Experience",
+//         description: "Everything in VIP Pass plus:",
+//         benefits: [
+//           "Backstage Tour & meet-and-greet with performers",
+//           "Access to after-party events",
+//           "Festival merch bundle (shirt + wristband + tote)",
+//         ],
+//         price: 0.4,
+//         remaining: 30,
+//       },
+//     ],
+//   },
+//   {
+//     id: "electronic-music-night-2",
+//     name: "Electronic Music Nights",
+//     image: "/images/events/detail2.png",
+//     date: "July 8, 2024",
+//     time: "9:00 PM - 4:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.05 ETH",
+//     priceInEth: 0.05,
+//     category: "vip",
+//     featured: false,
+//     attendees: 800,
+//     description:
+//       "Experience the best electronic music under the stars. World-class DJs and incredible light shows await.",
+//     organizer: {
+//       name: "Beat Collective",
+//       verified: true,
+//       description: "Electronic music events since 2015",
+//     },
+//   },
+//   {
+//     id: "summer-dance-festival-2",
+//     name: "Summer Dance Festival",
+//     image: "/images/events/detail.png",
+//     date: "June 15-17, 2024",
+//     time: "6:00 PM - 2:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.08 ETH",
+//     priceInEth: 0.08,
+//     category: "festival",
+//     featured: false,
+//     attendees: 1200,
+//   },
+//   {
+//     id: "electronic-music-night-2",
+//     name: "Electronic Music Night",
+//     image: "/images/events/detail2.png",
+//     date: "July 8, 2024",
+//     time: "9:00 PM - 4:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.05 ETH",
+//     priceInEth: 0.05,
+//     category: "vip",
+//     featured: false,
+//     attendees: 800,
+//   },
+// ];
+
+// export const getEventsByCategory = (category: string): Event[] => {
+//   if (category === "all") return mockEvents;
+//   return mockEvents.filter((event) => event.category === category);
+// };
+
+// export const getFeaturedEvents = (): Event[] => {
+//   return mockEvents.filter((event) => event.featured);
+// };
+
+// export const getEventById = (id: string): Event | undefined => {
+//   return mockEvents.find((event) => event.id === id);
+// };
+
 import type { Event } from "@/types/event";
 
 /**
@@ -6,7 +131,7 @@ import type { Event } from "@/types/event";
  */
 export const mockEvents: Event[] = [
   {
-    id: "summer-dance-festival-1",
+    id: "summer-dance-festival-2",
     name: "Summer Dance Festival",
     image: "/images/events/detail.png",
     date: "June 15-17, 2024",
@@ -60,8 +185,8 @@ export const mockEvents: Event[] = [
     ],
   },
   {
-    id: "electronic-music-night-1",
-    name: "Electronic Music Night",
+    id: "electronic-music-night-2",
+    name: "Electronic Music Nights",
     image: "/images/events/detail2.png",
     date: "July 8, 2024",
     time: "9:00 PM - 4:00 AM",
@@ -69,7 +194,7 @@ export const mockEvents: Event[] = [
     venue: "Central Park",
     price: "0.05 ETH",
     priceInEth: 0.05,
-    category: "music",
+    category: "vip",
     featured: false,
     attendees: 800,
     description:
@@ -104,7 +229,7 @@ export const mockEvents: Event[] = [
     venue: "Central Park",
     price: "0.05 ETH",
     priceInEth: 0.05,
-    category: "music",
+    category: "vip",
     featured: false,
     attendees: 800,
   },

--- a/src/mocks/lamdings,ts
+++ b/src/mocks/lamdings,ts
@@ -1,0 +1,342 @@
+import type { HowItWorksStep, TrendingEvent } from "@/types/landing";
+
+export const trendingEvents: TrendingEvent[] = [
+  {
+    id: 1,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "$50",
+    category: "Music",
+    image: "/djparty.png",
+  },
+  {
+    id: 2,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "0.05ETH",
+    category: "Music",
+    image: "/djparty.png",
+  },
+  {
+    id: 3,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "$50",
+    category: "Music",
+    image: "/djparty.png",
+  },
+  {
+    id: 4,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "$50",
+    category: "Music",
+    image: "/djparty.png",
+  },
+  {
+    id: 5,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "$50",
+    category: "Music",
+    image: "/djparty.png",
+  },
+  {
+    id: 6,
+    title: "Metaverse Festival",
+    location: "Abuja, Nigeria",
+    date: "Oct 21, 2025",
+    time: "7:00PM",
+    price: "$50",
+    category: "Music",
+    image: "/djparty.png",
+  },
+];
+
+export const howItWorksSteps: HowItWorksStep[] = [
+  {
+    id: 1,
+    title: "Find Your Vibe",
+    description:
+      "Discover live concerts, NFT drops, or virtual meetups. Whether you love music, sports, or art, we've got you covered. Filter or dive in and explore!",
+  },
+  {
+    id: 2,
+    title: "Choose Your Adventure",
+    description:
+      "Found your event? Pick your ticket-General, VIP, or NFT. Own, trade, or flex your NFT tickets. Your choice, your style!",
+  },
+  {
+    id: 3,
+    title: "Lock It In",
+    description:
+      "Secure your spot with seamless checkout and keep your ticket in your wallet for easy access anytime.",
+  },
+  {
+    id: 4,
+    title: "Show Up, Stand Out",
+    description:
+      "Attend your event, earn rewards, and show off your collection as proof of the moments you've owned.",
+  },
+];
+
+
+// import type { Event } from "@/types/event";
+
+// /**
+//  * Centralized mock event data for public and protected experiences.
+//  * Replace these exports with API calls in the next wave.
+//  */
+// export const mockEvents: Event[] = [
+//   {
+//     id: "summer-dance-festival-2",
+//     name: "Summer Dance Festival",
+//     image: "/images/events/detail.png",
+//     date: "June 15-17, 2024",
+//     dateEnd: "June 17, 2024",
+//     time: "6:00 PM - 2:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.08 ETH",
+//     priceInEth: 0.08,
+//     category: "festival",
+//     featured: true,
+//     attendees: 1200,
+//     description:
+//       "Get ready to move at the ultimate Summer Dance Festival of 2024 — a high-energy celebration of music, culture, and community under the open sky. This unforgettable two-day experience brings together DJs, dance crews, and music lovers from around the world for a weekend packed with rhythm, beats, and unforgettable vibes.",
+//     organizer: {
+//       name: "Rhythm Nation Collective",
+//       verified: true,
+//       description: "Bringing immersive music experiences to life",
+//     },
+//     ticketOptions: [
+//       {
+//         name: "General Admission",
+//         description: "Access to all stages and performances",
+//         benefits: ["Entry to food courts and chill-out lounges"],
+//         price: 0.08,
+//         remaining: 200,
+//         popular: true,
+//       },
+//       {
+//         name: "VIP Pass",
+//         description: "Everything in General Admission plus:",
+//         benefits: [
+//           "Priority entry",
+//           "Exclusive access to VIP dance pit and lounges",
+//           "Complimentary drink vouchers (x2)",
+//         ],
+//         price: 0.2,
+//         remaining: 70,
+//       },
+//       {
+//         name: "All-Access Experience",
+//         description: "Everything in VIP Pass plus:",
+//         benefits: [
+//           "Backstage Tour & meet-and-greet with performers",
+//           "Access to after-party events",
+//           "Festival merch bundle (shirt + wristband + tote)",
+//         ],
+//         price: 0.4,
+//         remaining: 30,
+//       },
+//     ],
+//   },
+//   {
+//     id: "electronic-music-night-2",
+//     name: "Electronic Music Nights",
+//     image: "/images/events/detail2.png",
+//     date: "July 8, 2024",
+//     time: "9:00 PM - 4:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.05 ETH",
+//     priceInEth: 0.05,
+//     category: "vip",
+//     featured: false,
+//     attendees: 800,
+//     description:
+//       "Experience the best electronic music under the stars. World-class DJs and incredible light shows await.",
+//     organizer: {
+//       name: "Beat Collective",
+//       verified: true,
+//       description: "Electronic music events since 2015",
+//     },
+//   },
+//   {
+//     id: "summer-dance-festival-2",
+//     name: "Summer Dance Festival",
+//     image: "/images/events/detail.png",
+//     date: "June 15-17, 2024",
+//     time: "6:00 PM - 2:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.08 ETH",
+//     priceInEth: 0.08,
+//     category: "festival",
+//     featured: false,
+//     attendees: 1200,
+//   },
+//   {
+//     id: "electronic-music-night-2",
+//     name: "Electronic Music Night",
+//     image: "/images/events/detail2.png",
+//     date: "July 8, 2024",
+//     time: "9:00 PM - 4:00 AM",
+//     location: "Central Park, New York",
+//     venue: "Central Park",
+//     price: "0.05 ETH",
+//     priceInEth: 0.05,
+//     category: "vip",
+//     featured: false,
+//     attendees: 800,
+//   },
+// ];
+
+// export const getEventsByCategory = (category: string): Event[] => {
+//   if (category === "all") return mockEvents;
+//   return mockEvents.filter((event) => event.category === category);
+// };
+
+// export const getFeaturedEvents = (): Event[] => {
+//   return mockEvents.filter((event) => event.featured);
+// };
+
+// export const getEventById = (id: string): Event | undefined => {
+//   return mockEvents.find((event) => event.id === id);
+// };
+
+import type { Event } from "@/types/event";
+
+/**
+ * Centralized mock event data for public and protected experiences.
+ * Replace these exports with API calls in the next wave.
+ */
+export const mockEvents: Event[] = [
+  {
+    id: "summer-dance-festival-2",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    dateEnd: "June 17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: true,
+    attendees: 1200,
+    description:
+      "Get ready to move at the ultimate Summer Dance Festival of 2024 — a high-energy celebration of music, culture, and community under the open sky. This unforgettable two-day experience brings together DJs, dance crews, and music lovers from around the world for a weekend packed with rhythm, beats, and unforgettable vibes.",
+    organizer: {
+      name: "Rhythm Nation Collective",
+      verified: true,
+      description: "Bringing immersive music experiences to life",
+    },
+    ticketOptions: [
+      {
+        name: "General Admission",
+        description: "Access to all stages and performances",
+        benefits: ["Entry to food courts and chill-out lounges"],
+        price: 0.08,
+        remaining: 200,
+        popular: true,
+      },
+      {
+        name: "VIP Pass",
+        description: "Everything in General Admission plus:",
+        benefits: [
+          "Priority entry",
+          "Exclusive access to VIP dance pit and lounges",
+          "Complimentary drink vouchers (x2)",
+        ],
+        price: 0.2,
+        remaining: 70,
+      },
+      {
+        name: "All-Access Experience",
+        description: "Everything in VIP Pass plus:",
+        benefits: [
+          "Backstage Tour & meet-and-greet with performers",
+          "Access to after-party events",
+          "Festival merch bundle (shirt + wristband + tote)",
+        ],
+        price: 0.4,
+        remaining: 30,
+      },
+    ],
+  },
+  {
+    id: "electronic-music-night-2",
+    name: "Electronic Music Nights",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "vip",
+    featured: false,
+    attendees: 800,
+    description:
+      "Experience the best electronic music under the stars. World-class DJs and incredible light shows await.",
+    organizer: {
+      name: "Beat Collective",
+      verified: true,
+      description: "Electronic music events since 2015",
+    },
+  },
+  {
+    id: "summer-dance-festival-2",
+    name: "Summer Dance Festival",
+    image: "/images/events/detail.png",
+    date: "June 15-17, 2024",
+    time: "6:00 PM - 2:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.08 ETH",
+    priceInEth: 0.08,
+    category: "festival",
+    featured: false,
+    attendees: 1200,
+  },
+  {
+    id: "electronic-music-night-2",
+    name: "Electronic Music Night",
+    image: "/images/events/detail2.png",
+    date: "July 8, 2024",
+    time: "9:00 PM - 4:00 AM",
+    location: "Central Park, New York",
+    venue: "Central Park",
+    price: "0.05 ETH",
+    priceInEth: 0.05,
+    category: "vip",
+    featured: false,
+    attendees: 800,
+  },
+];
+
+export const getEventsByCategory = (category: string): Event[] => {
+  if (category === "all") return mockEvents;
+  return mockEvents.filter((event) => event.category === category);
+};
+
+export const getFeaturedEvents = (): Event[] => {
+  return mockEvents.filter((event) => event.featured);
+};
+
+export const getEventById = (id: string): Event | undefined => {
+  return mockEvents.find((event) => event.id === id);
+};


### PR DESCRIPTION
 FE-179 Add ESLint rule to ban direct img tag usage in favour of AppImage


Description
Rawtags bypass Next.js image optimisation. Add a custom ESLint rule (or use @next/next/no-img-element) to ban them and enforce AppImage usage.

Acceptance Criteria
 ESLint config includes @next/next/no-img-element as an error.
 Existing violations are fixed as part of this issue.
 CI lint step fails on any new rawusage.
 closes #299