### PR TITLE
fix: remove incomplete duplicate eventImgs declaration in dashboard/page.tsx

### DIFF
--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -55,7 +55,6 @@ export default function DashboardPage() {
   const nextSettlementDays = data?.nextSettlementDays ?? 0
 
   const eventImgs = data?.events?.slice(0, 4).map((e) => ({
-  const eventImages = data?.events?.slice(0, 4).map((e) => ({
     src: e.coverImage ?? null,
     alt: e.name,
   })) ?? []


### PR DESCRIPTION
## Summary

Fixes a three-way merge artifact in `src/app/(protected)/dashboard/page.tsx` that produced two back-to-back variable declarations for the same data:

```tsx
const eventImgs = data?.events?.slice(0, 4).map((e) => ({  // ← incomplete, no body
const eventImages = data?.events?.slice(0, 4).map((e) => ({  // ← complete but wrong name
  src: e.coverImage ?? null,
  alt: e.name,
})) ?? []
```

## Changes

- Deleted the syntactically incomplete `const eventImgs = ...` line
- Renamed `eventImages` → `eventImgs` to match the `eventImgs.map()` reference in JSX below

## Testing

- `npm run build` — zero TypeScript errors introduced by this file (pre-existing unrelated errors exist on `main`)
- Only one `const eventImgs` declaration remains; JSX reference resolves correctly

Closes #360