### PR TITLE
fix: merge duplicate React hook imports in verify/page.tsx

### DIFF
--- a/src/app/(protected)/verify/page.tsx
+++ b/src/app/(protected)/verify/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';


### PR DESCRIPTION
## Summary

Fixes a merge artifact in `src/app/(protected)/verify/page.tsx` that left the same React hooks imported twice:

```tsx
import { useEffect, useRef, useState } from 'react';   // line 1 — duplicate
import { useState, useRef, useEffect } from 'react';   // line 2 — duplicate
```

TypeScript flags duplicate identifiers from these overlapping imports as an error.

## Changes

- Removed one of the duplicate import lines
- Kept `import { useState, useRef, useEffect } from 'react'`
- Audited the rest of the file — no other duplicate imports found

## Testing

- `npm run build` — the TypeScript error from the duplicate import in this file is resolved; no new errors introduced
- All hook usages (`useState`, `useRef`, `useEffect`) remain correctly referenced

Closes #361