### PR TITLE
fix: replace VALID_TICKETS mock with real POST /api/verification/verify call

### DIFF
--- a/src/app/(protected)/verify/page.tsx
+++ b/src/app/(protected)/verify/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -17,35 +16,7 @@ import {
   getVerificationErrorMessage,
   type VerificationErrorType,
 } from '@/lib/verificationErrors';
-
-// ─── Mock Data ────────────────────────────────────────────────────────────────
-const VALID_TICKETS: Record<string, {
-  holderName: string;
-  ticketType: string;
-  event: string;
-  date: string;
-  seat?: string;
-}> = {
-  'TKT-2024-ALPHA-001': {
-    holderName: 'Jordan Rivera',
-    ticketType: 'VIP Pass',
-    event: 'Summer Dance Festival',
-    date: 'Aug 15, 2025',
-    seat: 'VIP Zone A',
-  },
-  'TKT-2024-BETA-042': {
-    holderName: 'Morgan Chen',
-    ticketType: 'General Admission',
-    event: 'Summer Dance Festival',
-    date: 'Aug 15, 2025',
-  },
-  'TKT-2024-GAMMA-199': {
-    holderName: 'Alex Morales',
-    ticketType: 'Early Bird',
-    event: 'Summer Dance Festival',
-    date: 'Aug 15, 2025',
-  },
-};
+import { verifyTicket, type VerificationResult } from '@/features/verification/api';
 
 type VerifyState =
   | 'idle'
@@ -57,9 +28,6 @@ type VerifyState =
   | 'network-error'
   | 'unknown-error';
 
-// Maps the page-level VerifyState onto the canonical VerificationErrorType
-// codes defined in src/lib/verificationErrors.ts. Unknown states fall through
-// to the generic message via getVerificationErrorMessage's fallback.
 const STATE_TO_ERROR_TYPE: Partial<Record<VerifyState, VerificationErrorType>> = {
   failure: 'invalid-ticket',
   'already-used': 'already-used',
@@ -71,7 +39,6 @@ const STATE_TO_ERROR_TYPE: Partial<Record<VerifyState, VerificationErrorType>> =
 function ScanFrame() {
   return (
     <div className="relative w-56 h-56 mx-auto">
-      {/* Corner brackets */}
       {['top-left', 'top-right', 'bottom-left', 'bottom-right'].map((corner) => {
         const isTop = corner.startsWith('top');
         const isLeft = corner.endsWith('left');
@@ -90,14 +57,12 @@ function ScanFrame() {
         );
       })}
 
-      {/* Scan line */}
       <motion.div
         className="absolute left-2 right-2 h-0.5 bg-gradient-to-r from-transparent via-[#21D4FF] to-transparent"
         animate={{ top: ['10%', '90%', '10%'] }}
         transition={{ duration: 2.5, repeat: Infinity, ease: 'easeInOut' }}
       />
 
-      {/* Inner grid pattern (decorative) */}
       <div className="absolute inset-4 opacity-10">
         <div
           className="w-full h-full"
@@ -117,23 +82,21 @@ function ScanFrame() {
 function ResultCard({
   state,
   ticketCode,
+  ticketDetails,
   onReset,
   onRetry,
 }: {
   state: VerifyState;
   ticketCode: string;
+  ticketDetails: VerificationResult | null;
   onReset: () => void;
   onRetry?: () => void;
 }) {
-  const ticket = VALID_TICKETS[ticketCode.toUpperCase()];
   const isSuccess = state === 'success';
   const isAlreadyUsed = state === 'already-used';
   const isServiceError = state === 'service-error';
   const isNetworkError = state === 'network-error';
 
-  // Pull a user-friendly, actionable message bundle from the central
-  // mapping so all error UIs stay consistent. Unknown states get the
-  // generic fallback from getVerificationErrorMessage automatically.
   const errorMessage = !isSuccess
     ? getVerificationErrorMessage(STATE_TO_ERROR_TYPE[state])
     : null;
@@ -194,17 +157,15 @@ function ResultCard({
 
         {/* Ticket Details */}
         <div className="p-6 space-y-4">
-          {isSuccess && ticket ? (
-            <>
-              <div className="grid grid-cols-2 gap-4">
-                <Detail label="Holder" value={ticket.holderName} />
-                <Detail label="Ticket Type" value={ticket.ticketType} />
-                <Detail label="Event" value={ticket.event} />
-                <Detail label="Date" value={ticket.date} />
-                {ticket.seat && <Detail label="Zone / Seat" value={ticket.seat} />}
-                <Detail label="Code" value={ticketCode.toUpperCase()} mono />
-              </div>
-            </>
+          {isSuccess && ticketDetails ? (
+            <div className="grid grid-cols-2 gap-4">
+              {ticketDetails.holderName && <Detail label="Holder" value={ticketDetails.holderName} />}
+              {ticketDetails.ticketType && <Detail label="Ticket Type" value={ticketDetails.ticketType} />}
+              {ticketDetails.event && <Detail label="Event" value={ticketDetails.event} />}
+              {ticketDetails.date && <Detail label="Date" value={ticketDetails.date} />}
+              {ticketDetails.seat && <Detail label="Zone / Seat" value={ticketDetails.seat} />}
+              <Detail label="Code" value={ticketCode.toUpperCase()} mono />
+            </div>
           ) : (
             <div className="text-center py-4 space-y-2">
               <p className="text-gray-300 text-sm">{errorMessage?.description}</p>
@@ -260,65 +221,62 @@ export default function VerifyPage() {
   const router = useRouter();
   const [code, setCode] = useState('');
   const [verifyState, setVerifyState] = useState<VerifyState>('idle');
-  const [usedCodes] = useState<Set<string>>(new Set());
+  const [ticketDetails, setTicketDetails] = useState<VerificationResult | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Autofocus input on mount
   useEffect(() => { inputRef.current?.focus(); }, []);
+
+  const runVerify = async (ticketCode: string) => {
+    setVerifyState('loading');
+    setTicketDetails(null);
+
+    try {
+      const { ok, status, data } = await verifyTicket(ticketCode);
+
+      if (!ok) {
+        setVerifyState(status >= 500 ? 'service-error' : 'failure');
+        return;
+      }
+
+      if (!data) {
+        setVerifyState('service-error');
+        return;
+      }
+
+      switch (data.status) {
+        case 'VALID':
+          setTicketDetails(data);
+          setVerifyState('success');
+          break;
+        case 'ALREADY_USED':
+          setVerifyState('already-used');
+          break;
+        case 'INVALID':
+        case 'CANCELLED':
+          setVerifyState('failure');
+          break;
+        default:
+          setVerifyState('failure');
+      }
+    } catch {
+      // fetch() threw — network unreachable
+      setVerifyState('network-error');
+    }
+  };
 
   const handleVerify = () => {
     if (!code.trim()) return;
-    setVerifyState('loading');
-
-    // Simulate async check with potential service failure
-    setTimeout(() => {
-      const upper = code.trim().toUpperCase();
-      
-      // Deterministic service error for testing
-      if (upper === 'TKT-SERVICE-ERR') {
-        setVerifyState('service-error');
-        return;
-      }
-
-      // Simulate random service failure (10% chance for other codes)
-      const simulateServiceError = Math.random() < 0.1;
-      
-      if (simulateServiceError) {
-        setVerifyState('service-error');
-        return;
-      }
-
-      if (usedCodes.has(upper)) {
-        setVerifyState('already-used');
-      } else if (VALID_TICKETS[upper]) {
-        usedCodes.add(upper);
-        setVerifyState('success');
-      } else {
-        setVerifyState('failure');
-      }
-    }, 900);
+    runVerify(code);
   };
 
   const handleReset = () => {
     setCode('');
     setVerifyState('idle');
+    setTicketDetails(null);
     inputRef.current?.focus();
   };
 
-  const handleRetry = () => {
-    setVerifyState('loading');
-    setTimeout(() => {
-      const upper = code.trim().toUpperCase();
-      if (usedCodes.has(upper)) {
-        setVerifyState('already-used');
-      } else if (VALID_TICKETS[upper]) {
-        usedCodes.add(upper);
-        setVerifyState('success');
-      } else {
-        setVerifyState('failure');
-      }
-    }, 900);
-  };
+  const handleRetry = () => runVerify(code);
 
   const isChecking = verifyState === 'loading';
   const hasResult = [
@@ -334,7 +292,6 @@ export default function VerifyPage() {
     <div className="min-h-screen bg-primary-dark-blue">
       {/* Hero Header */}
       <section className="relative overflow-hidden">
-        {/* Background decoration */}
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute -top-20 -left-20 w-96 h-96 rounded-full bg-[#4D21FF]/10 blur-3xl" />
           <div className="absolute -top-10 right-0 w-64 h-64 rounded-full bg-[#21D4FF]/10 blur-3xl" />
@@ -362,7 +319,7 @@ export default function VerifyPage() {
             </div>
             <div>
               <h1 className="text-3xl sm:text-4xl font-bold text-white">Ticket Verification</h1>
-              <p className="text-gray-400 text-sm mt-0.5">Summer Dance Festival · Staff Portal</p>
+              <p className="text-gray-400 text-sm mt-0.5">Staff Portal</p>
             </div>
           </motion.div>
         </div>
@@ -447,34 +404,6 @@ export default function VerifyPage() {
                     </>
                   )}
                 </motion.button>
-
-                {/* Test hints */}
-                <div className="pt-2 border-t border-white/5">
-                  <p className="text-gray-600 text-xs mb-2">Try these demo codes:</p>
-                  <div className="flex flex-wrap gap-2">
-                    {Object.keys(VALID_TICKETS).map((k) => (
-                      <button
-                        key={k}
-                        onClick={() => setCode(k)}
-                        className="text-xs font-mono px-2 py-1 rounded-md bg-white/5 text-gray-400 hover:bg-[#4D21FF]/20 hover:text-white transition-colors"
-                      >
-                        {k}
-                      </button>
-                    ))}
-                    <button
-                      onClick={() => setCode('TKT-INVALID-000')}
-                      className="text-xs font-mono px-2 py-1 rounded-md bg-white/5 text-gray-400 hover:bg-red-500/20 hover:text-red-300 transition-colors"
-                    >
-                      TKT-INVALID-000
-                    </button>
-                    <button
-                      onClick={() => setCode('TKT-SERVICE-ERR')}
-                      className="text-xs font-mono px-2 py-1 rounded-md bg-white/5 text-gray-400 hover:bg-orange-500/20 hover:text-orange-300 transition-colors"
-                    >
-                      SERVICE ERROR TEST
-                    </button>
-                  </div>
-                </div>
               </div>
             </motion.div>
           )}
@@ -484,6 +413,7 @@ export default function VerifyPage() {
             <ResultCard
               state={verifyState}
               ticketCode={code}
+              ticketDetails={ticketDetails}
               onReset={handleReset}
               onRetry={handleRetry}
             />

--- a/src/features/verification/api.ts
+++ b/src/features/verification/api.ts
@@ -1,0 +1,35 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export interface VerificationResult {
+  status: 'VALID' | 'ALREADY_USED' | 'INVALID' | 'CANCELLED';
+  holderName?: string;
+  ticketType?: string;
+  event?: string;
+  date?: string;
+  seat?: string;
+}
+
+/**
+ * POST /api/verification/verify
+ * Sends a ticket code to the backend and returns the verification result.
+ * Throws a TypeError (network error) if the request cannot be made.
+ * Returns the raw Response for HTTP-level error inspection by the caller.
+ */
+export async function verifyTicket(ticketCode: string): Promise<{
+  ok: boolean;
+  status: number;
+  data: VerificationResult | null;
+}> {
+  const res = await fetch(`${API_BASE}/api/verification/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ticketCode: ticketCode.trim() }),
+  });
+
+  if (!res.ok) {
+    return { ok: false, status: res.status, data: null };
+  }
+
+  const data: VerificationResult = await res.json();
+  return { ok: true, status: res.status, data };
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `VALID_TICKETS` in-memory object and `setTimeout`-based mock verification with a real call to `POST /api/verification/verify`.

## Changes

### New file: `src/features/verification/api.ts`
- `verifyTicket(ticketCode)` — posts `{ ticketCode }` to `${NEXT_PUBLIC_API_BASE_URL}/api/verification/verify`
- Returns `{ ok, status, data }` — caller handles HTTP errors and maps to `VerifyState`
- Network errors (fetch throws) propagate as `TypeError` for the caller to catch

### Updated: `src/app/(protected)/verify/page.tsx`
- Deleted `VALID_TICKETS` constant and all references
- Replaced `handleVerify` / `handleRetry` with `runVerify()` — a real async function using `verifyTicket()`
- Status mapping:
  | API `status` | `VerifyState` |
  |---|---|
  | `VALID` | `success` |
  | `ALREADY_USED` | `already-used` |
  | `INVALID` / `CANCELLED` | `failure` |
  | HTTP 5xx | `service-error` |
  | fetch throws | `network-error` |
- `ticketDetails` state stores the `VerificationResult` from the API; `ResultCard` now renders real holder name, ticket type, event, date, and seat
- Removed the demo code buttons (valid tickets, `TKT-INVALID-000`, `SERVICE ERROR TEST`)
- Removed the client-side `usedCodes` Set (server is authoritative)
- All existing UI states preserved: loading spinner, `ScanFrame`, `ResultCard` variants

## Testing

- `npm run build` — zero TypeScript errors introduced by these files (9 pre-existing unrelated errors on `main` are unchanged)
- All `VerifyState` branches covered by the switch statement with a default fallback

Closes #362