### PR TITLE
feat: add Stellar payment instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.4",
         "next-pwa": "^5.6.0",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
@@ -10241,6 +10242,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.4",
     "next-mdx-remote": "^5.0.0",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",

--- a/src/__tests__/stellar-payment-instructions.test.tsx
+++ b/src/__tests__/stellar-payment-instructions.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StellarPaymentInstructions } from "@/features/orders/components/StellarPaymentInstructions";
+import { toast } from "react-toastify";
+
+const push = vi.fn();
+const writeText = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("StellarPaymentInstructions", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "PENDING" }),
+    }) as unknown as typeof fetch;
+  });
+
+  it("renders Stellar payment details and copy controls", async () => {
+    render(
+      <StellarPaymentInstructions
+        orderId="order-1"
+        destinationAddress="GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        memo="MEMO-123"
+        amountXLM="25.5"
+      />
+    );
+
+    expect(screen.getByText("Complete your ticket payment")).toBeInTheDocument();
+    expect(screen.getByText("Required - your payment will fail without the memo")).toBeInTheDocument();
+    expect(screen.getByText("25.5 XLM")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy destination address/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy memo/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /copy amount/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/orders/order-1", expect.any(Object));
+    });
+  });
+
+  it("redirects to tickets when polling returns PAID", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "PAID" }),
+    }) as unknown as typeof fetch;
+
+    render(
+      <StellarPaymentInstructions
+        orderId="order-paid"
+        destinationAddress="GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        memo="MEMO-PAID"
+        amountXLM={12}
+      />
+    );
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("🎉 Tickets issued! Check your email.");
+      expect(push).toHaveBeenCalledWith("/tickets");
+    });
+  });
+
+  it("retries an expired payment window", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "PENDING" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          destinationAddress: "GNEWDESTINATION",
+          memo: "NEW-MEMO",
+          amountXLM: "30",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "PENDING" }),
+      }) as unknown as typeof fetch;
+
+    render(
+      <StellarPaymentInstructions
+        orderId="order-expired"
+        destinationAddress="GOLDDESTINATION"
+        memo="OLD-MEMO"
+        amountXLM="20"
+        expiresAt={new Date(Date.now() - 1000)}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /retry payment/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/orders/order-expired/retry-payment", {
+        method: "POST",
+      });
+      expect(screen.getByText("NEW-MEMO")).toBeInTheDocument();
+      expect(toast.success).toHaveBeenCalledWith("Payment window refreshed.");
+    });
+  });
+});

--- a/src/__tests__/stellar-payment-instructions.test.tsx
+++ b/src/__tests__/stellar-payment-instructions.test.tsx
@@ -44,7 +44,7 @@ describe("StellarPaymentInstructions", () => {
     );
 
     expect(screen.getByText("Complete your ticket payment")).toBeInTheDocument();
-    expect(screen.getByText("Required - your payment will fail without the memo")).toBeInTheDocument();
+    expect(screen.getByText("Required — your payment will fail without the memo")).toBeInTheDocument();
     expect(screen.getByText("25.5 XLM")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /copy destination address/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /copy memo/i })).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("StellarPaymentInstructions", () => {
     );
 
     await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("🎉 Tickets issued! Check your email.");
+      expect(toast.success).toHaveBeenCalledWith("\uD83C\uDF89 Tickets issued! Check your email.");
       expect(push).toHaveBeenCalledWith("/tickets");
     });
   });

--- a/src/features/orders/components/StellarPaymentInstructions.tsx
+++ b/src/features/orders/components/StellarPaymentInstructions.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { QRCodeSVG } from "qrcode.react";
+import { toast } from "react-toastify";
+import { Check, Clock, Copy, RefreshCw, TicketCheck } from "lucide-react";
+import { useOrderStatus } from "@/hooks/useOrderStatus";
+
+type StellarPaymentInstructionsProps = {
+  orderId: string;
+  destinationAddress: string;
+  memo: string;
+  amountXLM: string | number;
+  expiresAt?: string | Date;
+  expiresInMinutes?: number;
+  className?: string;
+};
+
+type RetryPaymentResponse = {
+  destinationAddress?: string;
+  memo?: string;
+  amountXLM?: string | number;
+  expiresAt?: string;
+};
+
+const DEFAULT_EXPIRY_MINUTES = 15;
+
+function normalizeAmount(amount: string | number) {
+  return typeof amount === "number" ? amount.toFixed(7).replace(/\.?0+$/, "") : amount;
+}
+
+function truncateAddress(address: string) {
+  if (address.length <= 18) return address;
+  return `${address.slice(0, 8)}...${address.slice(-8)}`;
+}
+
+function getInitialExpiry(expiresAt?: string | Date, expiresInMinutes = DEFAULT_EXPIRY_MINUTES) {
+  if (expiresAt) return new Date(expiresAt).getTime();
+  return Date.now() + expiresInMinutes * 60_000;
+}
+
+function formatRemaining(milliseconds: number) {
+  const totalSeconds = Math.max(0, Math.ceil(milliseconds / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function StellarPaymentInstructions({
+  orderId,
+  destinationAddress,
+  memo,
+  amountXLM,
+  expiresAt,
+  expiresInMinutes = DEFAULT_EXPIRY_MINUTES,
+  className = "",
+}: StellarPaymentInstructionsProps) {
+  const router = useRouter();
+  const [payment, setPayment] = useState({
+    destinationAddress,
+    memo,
+    amountXLM,
+    expiresAt: getInitialExpiry(expiresAt, expiresInMinutes),
+  });
+  const [now, setNow] = useState(() => Date.now());
+  const [copiedField, setCopiedField] = useState<"destination" | "memo" | "amount" | null>(null);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const { data, error, isLoading, refetch } = useOrderStatus(orderId, {
+    enabled: Boolean(orderId),
+    intervalMs: 5000,
+  });
+
+  const amount = normalizeAmount(payment.amountXLM);
+  const remainingMs = payment.expiresAt - now;
+  const isExpired = remainingMs <= 0;
+
+  const stellarPayUri = useMemo(() => {
+    const params = new URLSearchParams({
+      destination: payment.destinationAddress,
+      amount: String(amount),
+      memo: payment.memo,
+    });
+    return `web+stellar:pay?${params.toString()}`;
+  }, [amount, payment.destinationAddress, payment.memo]);
+
+  useEffect(() => {
+    // This syncs the local payment window when the backend returns a fresh order payload.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPayment({
+      destinationAddress,
+      memo,
+      amountXLM,
+      expiresAt: getInitialExpiry(expiresAt, expiresInMinutes),
+    });
+  }, [amountXLM, destinationAddress, expiresAt, expiresInMinutes, memo]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (data?.status === "PAID") {
+      toast.success("🎉 Tickets issued! Check your email.");
+      router.push("/tickets");
+    }
+  }, [data?.status, router]);
+
+  async function copyValue(field: "destination" | "memo" | "amount", value: string) {
+    await navigator.clipboard.writeText(value);
+    setCopiedField(field);
+    window.setTimeout(() => setCopiedField(null), 1800);
+  }
+
+  async function retryPayment() {
+    setIsRetrying(true);
+    try {
+      const response = await fetch(`/api/orders/${encodeURIComponent(orderId)}/retry-payment`, {
+        method: "POST",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Retry payment request failed with ${response.status}`);
+      }
+
+      const retryData = (await response.json()) as RetryPaymentResponse;
+      setPayment((current) => ({
+        destinationAddress: retryData.destinationAddress ?? current.destinationAddress,
+        memo: retryData.memo ?? current.memo,
+        amountXLM: retryData.amountXLM ?? current.amountXLM,
+        expiresAt: getInitialExpiry(retryData.expiresAt, expiresInMinutes),
+      }));
+      setNow(Date.now());
+      toast.success("Payment window refreshed.");
+      await refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not retry payment.");
+    } finally {
+      setIsRetrying(false);
+    }
+  }
+
+  return (
+    <section
+      className={`rounded-2xl border border-[#4D21FF]/30 bg-[#000625]/80 p-5 text-white shadow-[0_24px_60px_rgba(0,6,37,0.35)] ${className}`}
+      aria-labelledby="stellar-payment-title"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[#21D4FF]">
+            Stellar payment
+          </p>
+          <h2 id="stellar-payment-title" className="text-2xl font-bold">
+            Complete your ticket payment
+          </h2>
+          <p className="max-w-2xl text-sm leading-6 text-gray-300">
+            Send the exact XLM amount to the destination below and include the memo. The order
+            will auto-confirm once the payment is detected.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm">
+          <Clock className="h-4 w-4 text-[#21D4FF]" aria-hidden="true" />
+          {isExpired ? (
+            <span className="font-semibold text-red-300">Payment window expired</span>
+          ) : (
+            <span>
+              Expires in <strong>{formatRemaining(remainingMs)}</strong>
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[220px_1fr]">
+        <div className="rounded-xl border border-white/10 bg-white p-4">
+          <QRCodeSVG value={stellarPayUri} size={188} level="M" marginSize={2} />
+        </div>
+
+        <div className="space-y-4">
+          <PaymentRow
+            label="Destination address"
+            value={payment.destinationAddress}
+            displayValue={truncateAddress(payment.destinationAddress)}
+            copied={copiedField === "destination"}
+            onCopy={() => copyValue("destination", payment.destinationAddress)}
+          />
+          <PaymentRow
+            label="Memo"
+            value={payment.memo}
+            displayValue={payment.memo}
+            copied={copiedField === "memo"}
+            isCritical
+            onCopy={() => copyValue("memo", payment.memo)}
+          />
+          <PaymentRow
+            label="Amount"
+            value={`${amount} XLM`}
+            displayValue={`${amount} XLM`}
+            copied={copiedField === "amount"}
+            onCopy={() => copyValue("amount", String(amount))}
+          />
+
+          {isExpired ? (
+            <div className="rounded-xl border border-red-500/30 bg-red-950/40 p-4">
+              <p className="text-sm font-semibold text-red-200">This payment window expired.</p>
+              <p className="mt-1 text-sm text-red-100/80">
+                Retry payment to request a fresh memo and expiry window for this order.
+              </p>
+              <button
+                type="button"
+                onClick={retryPayment}
+                disabled={isRetrying}
+                className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <RefreshCw className={`h-4 w-4 ${isRetrying ? "animate-spin" : ""}`} aria-hidden="true" />
+                Retry Payment
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              <TicketCheck className="h-4 w-4 text-emerald-300" aria-hidden="true" />
+              {isLoading ? "Checking payment status..." : "Waiting for payment confirmation."}
+            </div>
+          )}
+
+          {error && (
+            <p role="alert" className="text-sm text-yellow-300">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type PaymentRowProps = {
+  label: string;
+  value: string;
+  displayValue: string;
+  copied: boolean;
+  isCritical?: boolean;
+  onCopy: () => void;
+};
+
+function PaymentRow({ label, value, displayValue, copied, isCritical = false, onCopy }: PaymentRowProps) {
+  return (
+    <div
+      className={`rounded-xl border p-4 ${
+        isCritical ? "border-red-500/40 bg-red-950/30" : "border-white/10 bg-white/5"
+      }`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className={`text-xs font-semibold uppercase tracking-wide ${isCritical ? "text-red-300" : "text-gray-400"}`}>
+            {label}
+          </p>
+          <p title={value} className="mt-1 break-all font-mono text-sm text-white">
+            {displayValue}
+          </p>
+          {isCritical && (
+            <p className="mt-2 text-sm font-semibold text-red-200">
+              Required - your payment will fail without the memo
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-sm font-semibold text-white transition hover:bg-white/10"
+          aria-label={`Copy ${label.toLowerCase()}`}
+        >
+          {copied ? <Check className="h-4 w-4 text-emerald-300" /> : <Copy className="h-4 w-4" />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/orders/components/StellarPaymentInstructions.tsx
+++ b/src/features/orders/components/StellarPaymentInstructions.tsx
@@ -25,6 +25,7 @@ type RetryPaymentResponse = {
 };
 
 const DEFAULT_EXPIRY_MINUTES = 15;
+const TICKETS_ISSUED_TOAST = "\uD83C\uDF89 Tickets issued! Check your email.";
 
 function normalizeAmount(amount: string | number) {
   return typeof amount === "number" ? amount.toFixed(7).replace(/\.?0+$/, "") : amount;
@@ -102,7 +103,7 @@ export function StellarPaymentInstructions({
 
   useEffect(() => {
     if (data?.status === "PAID") {
-      toast.success("🎉 Tickets issued! Check your email.");
+      toast.success(TICKETS_ISSUED_TOAST);
       router.push("/tickets");
     }
   }, [data?.status, router]);
@@ -261,7 +262,7 @@ function PaymentRow({ label, value, displayValue, copied, isCritical = false, on
           </p>
           {isCritical && (
             <p className="mt-2 text-sm font-semibold text-red-200">
-              Required - your payment will fail without the memo
+              Required — your payment will fail without the memo
             </p>
           )}
         </div>

--- a/src/hooks/useOrderStatus.ts
+++ b/src/hooks/useOrderStatus.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type OrderStatus = "PENDING" | "PAID" | "EXPIRED" | "FAILED" | "CANCELLED";
+
+export type OrderStatusResponse = {
+  id?: string;
+  status?: OrderStatus | string;
+  destinationAddress?: string;
+  memo?: string;
+  amountXLM?: string | number;
+  expiresAt?: string;
+  [key: string]: unknown;
+};
+
+type UseOrderStatusOptions = {
+  enabled?: boolean;
+  intervalMs?: number;
+};
+
+type UseOrderStatusResult = {
+  data: OrderStatusResponse | null;
+  error: string | null;
+  isLoading: boolean;
+  refetch: () => Promise<OrderStatusResponse | null>;
+};
+
+export function useOrderStatus(
+  orderId: string | null | undefined,
+  { enabled = true, intervalMs = 5000 }: UseOrderStatusOptions = {}
+): UseOrderStatusResult {
+  const [data, setData] = useState<OrderStatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!orderId) return null;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/orders/${encodeURIComponent(orderId)}`, {
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Order status request failed with ${response.status}`);
+      }
+
+      const nextData = (await response.json()) as OrderStatusResponse;
+      setData(nextData);
+      return nextData;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return null;
+      }
+
+      const message = err instanceof Error ? err.message : "Could not refresh order status.";
+      setError(message);
+      return null;
+    } finally {
+      if (abortRef.current === controller) {
+        setIsLoading(false);
+      }
+    }
+  }, [orderId]);
+
+  useEffect(() => {
+    if (!enabled || !orderId) return;
+
+    // Kick off an immediate poll before the interval so confirmation can redirect quickly.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refetch();
+    const timer = window.setInterval(() => {
+      void refetch();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(timer);
+      abortRef.current?.abort();
+    };
+  }, [enabled, intervalMs, orderId, refetch]);
+
+  return { data, error, isLoading, refetch };
+}


### PR DESCRIPTION
Closes #371

## Claim
/claim #371

## Summary
- Add `StellarPaymentInstructions` for the post-purchase Stellar payment flow: destination address, memo warning, amount, copy controls, QR code, countdown, expired state, and retry action.
- Add `useOrderStatus` to poll `GET /api/orders/:id` every 5 seconds and redirect to `/tickets` with the required success toast when the order becomes `PAID`.
- Add `qrcode.react` and focused coverage for rendering, PAID redirect, retry-payment behavior, and related CI-unblock fixes.

## Validation
- `npm run lint` -> passed with warnings only.
- `npm test` -> 25 test files passed, 242 tests passed; global coverage thresholds pass.
- `npm run build` -> passed.
- `npm ls qrcode.react` -> `qrcode.react@4.2.0` installed.

## Notes
- This PR keeps the implementation scoped to issue #371 and does not include the ticket-transfer scope from #370.