### PR TITLE
Implemented the event page

### DIFF
--- a/src/lib/animations/event.ts
+++ b/src/lib/animations/event.ts
@@ -1,0 +1,84 @@
+import { Variants } from "framer-motion";
+
+export const fadeInUp: Variants = {
+  hidden: { opacity: 0, y: 40 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};
+
+export const slideUp: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4 } },
+};
+
+export const fadeInDown: Variants = {
+  hidden: { opacity: 0, y: -20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const containerVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      staggerChildren: 0.12,
+      duration: 0.4,
+    },
+  },
+};
+
+export const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 10 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.25 } },
+};
+
+export const headerVariants: Variants = {
+  hidden: { opacity: 0, y: -10 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.3 } },
+};
+
+export const scaleIn: Variants = {
+  hidden: { opacity: 0, scale: 0.95 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.5 } },
+};
+
+export const slideInLeft: Variants = {
+  hidden: { opacity: 0, x: -40 },
+  visible: { opacity: 1, x: 0 },
+};
+
+export const slideInRight: Variants = {
+  hidden: { opacity: 0, x: 40 },
+  visible: { opacity: 1, x: 0 },
+};
+
+export const staggerContainer: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, duration: 0.5 },
+  },
+};
+
+export const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08 },
+  },
+};
+
+export const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const headerVariants: Variants = {
+  hidden: { opacity: 0, y: -10 },
+  visible: { opacity: 1, y: 0 },
+};

--- a/src/lib/ticket.ts
+++ b/src/lib/ticket.ts
@@ -95,4 +95,7 @@ export function classifyVerificationError(
   }
   const { description, retryable } = getVerificationErrorMessage(type);
   return { type, message: description, retryable };
+
+
+  
 }

--- a/src/lib/ticket.ts
+++ b/src/lib/ticket.ts
@@ -1,0 +1,98 @@
+// FE-085: Verification error state classification
+
+export type VerificationErrorType =
+  | "invalid-ticket"
+  | "already-used"
+  | "service-failure"
+  | "network-error";
+
+export interface VerificationError {
+  type: VerificationErrorType;
+  message: string;
+  retryable: boolean;
+}
+
+export interface VerificationErrorMessage {
+  /** Short headline shown in the result banner. */
+  title: string;
+  /** Actionable, user-friendly explanation shown to the operator. */
+  description: string;
+  /** Label for the primary CTA button. */
+  actionLabel: string;
+  /** Whether the operator should be encouraged to retry. */
+  retryable: boolean;
+}
+
+const VERIFICATION_ERROR_MESSAGES: Record<
+  VerificationErrorType,
+  VerificationErrorMessage
+> = {
+  "invalid-ticket": {
+    title: "Invalid ticket",
+    description:
+      "We couldn\u2019t find a ticket matching this code. Double-check the code with the attendee and try again.",
+    actionLabel: "Verify another ticket",
+    retryable: false,
+  },
+  "already-used": {
+    title: "Already used",
+    description:
+      "This ticket has already been checked in. Please direct the attendee to a supervisor for assistance.",
+    actionLabel: "Verify another ticket",
+    retryable: false,
+  },
+  "service-failure": {
+    title: "Service unavailable",
+    description:
+      "The verification service is temporarily unavailable. Please wait a moment and retry.",
+    actionLabel: "Retry verification",
+    retryable: true,
+  },
+  "network-error": {
+    title: "Connection lost",
+    description:
+      "We couldn\u2019t reach the verification service. Check your internet connection and try again.",
+    actionLabel: "Retry verification",
+    retryable: true,
+  },
+};
+
+export const FALLBACK_VERIFICATION_ERROR_MESSAGE: VerificationErrorMessage = {
+  title: "Verification failed",
+  description:
+    "Something went wrong while verifying this ticket. Please try again or contact support if the issue persists.",
+  actionLabel: "Try again",
+  retryable: true,
+};
+
+/**
+ * Maps a verification error code to a user-friendly message bundle.
+ * Unknown / missing codes fall back to a generic message instead of throwing.
+ */
+export function getVerificationErrorMessage(
+  type: VerificationErrorType | string | null | undefined,
+): VerificationErrorMessage {
+  if (!type) return FALLBACK_VERIFICATION_ERROR_MESSAGE;
+  return (
+    VERIFICATION_ERROR_MESSAGES[type as VerificationErrorType] ??
+    FALLBACK_VERIFICATION_ERROR_MESSAGE
+  );
+}
+
+export function classifyVerificationError(
+  httpStatus: number | null,
+  serverCode?: string,
+): VerificationError {
+  let type: VerificationErrorType;
+  if (httpStatus === null) {
+    type = "network-error";
+  } else if (httpStatus >= 500) {
+    type = "service-failure";
+  } else if (serverCode === "ALREADY_USED") {
+    type = "already-used";
+  } else {
+    type = "invalid-ticket";
+  }
+  const { description, retryable } = getVerificationErrorMessage(type);
+  return { type, message: description, retryable };
+}


### PR DESCRIPTION
 FE-xxx: feat: sync event page filter state to URL — make searches deep-linkable and shareable
Description
The events page filter state (search query, location, date, categories, view mode) is local React state. Sharing a filtered URL like /events?q=afrobeats&location=Lagos does not correctly restore filters on page load because the URL is only partially used.

What to do
Create src/hooks/useURLFilters.ts — a hook that syncs filter state to URL params via router.replace
Params: q, location, date, category (comma-separated), view (upcoming | featured)
Debounce URL updates by 300ms to avoid history spam on every keystroke
Initialize all state from URL params on mount (already partially done but incomplete)
Add a "Copy Search Link" button that copies window.location.href to clipboard
Update metadata based on active search: Search: "afrobeats" — VeriTix
Files touched
src/hooks/useURLFilters.ts (new)
src/app/(public)/events/page.tsx
closes #374


closes #369 
FE-xxx: feat: build my tickets listing page — paginated ticket list with QR display and download