### PR TITLE
feat: add attendee CSV export from event management attendees tab

### DIFF
--- a/src/components/events/manage/AttendeesTab.tsx
+++ b/src/components/events/manage/AttendeesTab.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Download, MoreVertical, Search } from "lucide-react";
+import { Download, Loader2, MoreVertical, Search } from "lucide-react";
 import { toast } from "react-toastify";
 import {
   type Attendee,
   banAttendee,
   checkInAttendee,
-  exportAttendeesCSV,
   fetchEventAttendees,
 } from "@/lib/attendeeManagement";
+import { exportAttendeesCsv, fetchAllTickets } from "@/lib/exportAttendeesCsv";
 import BanAttendeeDialog from "./BanAttendeeDialog";
 
 interface AttendeesTabProps {
@@ -26,6 +26,7 @@ export default function AttendeesTab({ eventId }: AttendeesTabProps) {
   const [page, setPage] = useState(1);
   const [checkingInId, setCheckingInId] = useState<string | null>(null);
   const [banningId, setBanningId] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
   const [showBanDialog, setShowBanDialog] = useState(false);
   const [selectedAttendee, setSelectedAttendee] = useState<Attendee | null>(null);
 
@@ -91,13 +92,53 @@ export default function AttendeesTab({ eventId }: AttendeesTabProps) {
     }
   };
 
-  const handleExport = () => {
-    if (attendees.length === 0) {
-      toast.info("No attendees to export.");
-      return;
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const tickets = await fetchAllTickets(eventId);
+      if (tickets.length === 0) {
+        toast.info("No attendees to export.");
+        return;
+      }
+      exportAttendeesCsv(tickets, eventId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Export failed.");
+    } finally {
+      setExporting(false);
     }
-    // Export everything currently loaded for this event (not just the filtered/paged view).
-    exportAttendeesCSV(attendees, eventId);
+  };
+
+  const handleOpenBanDialog = (attendee: Attendee) => {
+    setSelectedAttendee(attendee);
+    setShowBanDialog(true);
+  };
+
+  const handleCloseBanDialog = () => {
+    setShowBanDialog(false);
+    setSelectedAttendee(null);
+  };
+
+  const handleBan = async (reason: string) => {
+    if (!selectedAttendee) return;
+    setBanningId(selectedAttendee.id);
+    handleCloseBanDialog();
+    try {
+      const result = await banAttendee(eventId, selectedAttendee.id, reason);
+      if (!result.success) {
+        toast.error(result.message);
+        return;
+      }
+      setAttendees((prev) =>
+        prev.map((a) =>
+          a.id === selectedAttendee.id ? { ...a, banned: true, banReason: reason } : a,
+        ),
+      );
+      toast.success(`Banned ${selectedAttendee.name}.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Ban failed.");
+    } finally {
+      setBanningId(null);
+    }
   };
 
   return (
@@ -123,11 +164,15 @@ export default function AttendeesTab({ eventId }: AttendeesTabProps) {
         <button
           type="button"
           onClick={handleExport}
-          disabled={loading || attendees.length === 0}
+          disabled={loading || exporting}
           className="inline-flex items-center justify-center gap-2 rounded-lg border border-[#4D21FF]/40 bg-[#000625] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#4D21FF]/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4D21FF] disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <Download size={16} aria-hidden="true" />
-          Export CSV
+          {exporting ? (
+            <Loader2 size={16} aria-hidden="true" className="animate-spin" />
+          ) : (
+            <Download size={16} aria-hidden="true" />
+          )}
+          {exporting ? "Exporting…" : "Export CSV"}
         </button>
       </div>
 

--- a/src/lib/exportAttendeesCsv.ts
+++ b/src/lib/exportAttendeesCsv.ts
@@ -1,0 +1,65 @@
+export interface TicketRecord {
+  attendeeName: string;
+  attendeeEmail: string;
+  ticketType: string;
+  ticketCode: string;
+  status: string;
+  purchasedAt: string;
+}
+
+/** Fetch all tickets for an event, paginating if total > 1000. */
+export async function fetchAllTickets(eventId: string): Promise<TicketRecord[]> {
+  const PAGE = 1000;
+  const first = await fetch(`/api/events/${eventId}/tickets?limit=${PAGE}&offset=0`);
+  if (!first.ok) throw new Error("Failed to fetch tickets");
+  const firstData = await first.json();
+  const total: number = firstData.total ?? firstData.tickets?.length ?? 0;
+  const tickets: TicketRecord[] = mapTickets(firstData.tickets ?? firstData);
+
+  if (total > PAGE) {
+    const pages = Math.ceil(total / PAGE);
+    const requests = Array.from({ length: pages - 1 }, (_, i) =>
+      fetch(`/api/events/${eventId}/tickets?limit=${PAGE}&offset=${(i + 1) * PAGE}`)
+        .then((r) => r.json())
+        .then((d) => mapTickets(d.tickets ?? d)),
+    );
+    const rest = await Promise.all(requests);
+    rest.forEach((batch) => tickets.push(...batch));
+  }
+
+  return tickets;
+}
+
+function mapTickets(raw: any[]): TicketRecord[] {
+  return raw.map((t) => ({
+    attendeeName: t.attendeeName ?? t.attendee_name ?? "",
+    attendeeEmail: t.attendeeEmail ?? t.attendee_email ?? "",
+    ticketType: t.ticketType ?? t.ticket_type ?? "",
+    ticketCode: t.ticketCode ?? t.ticket_code ?? "",
+    status: t.status ?? "",
+    purchasedAt: t.purchasedAt ?? t.purchased_at ?? "",
+  }));
+}
+
+const HEADERS = ["attendeeName", "attendeeEmail", "ticketType", "ticketCode", "status", "purchasedAt"] as const;
+
+function escape(v: string): string {
+  return v.includes(",") || v.includes('"') || v.includes("\n")
+    ? `"${v.replace(/"/g, '""')}"`
+    : v;
+}
+
+export function exportAttendeesCsv(tickets: TicketRecord[], eventSlug: string): void {
+  const date = new Date().toISOString().slice(0, 10);
+  const rows = [
+    HEADERS.join(","),
+    ...tickets.map((t) => HEADERS.map((h) => escape(t[h])).join(",")),
+  ];
+  const blob = new Blob([rows.join("\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `veritix-attendees-${eventSlug}-${date}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Implements attendee CSV export from the event management attendees tab.

### Changes

- **`src/lib/exportAttendeesCsv.ts`** (new): `TicketRecord` interface, `fetchAllTickets` (paginates automatically when total > 1000 via `GET /api/events/:id/tickets?limit=1000`), and `exportAttendeesCsv` generating a file named `veritix-attendees-{eventSlug}-{YYYY-MM-DD}.csv` with columns: `attendeeName`, `attendeeEmail`, `ticketType`, `ticketCode`, `status`, `purchasedAt`.
- **`src/components/events/manage/AttendeesTab.tsx`**: replaced old `exportAttendeesCSV` with new helpers, `handleExport` is now async with a `Loader2` spinner while fetching, and added missing `handleOpenBanDialog`/`handleCloseBanDialog`/`handleBan` handlers.

### Tested
- TypeScript compilation passes for both modified files (pre-existing errors in unrelated files are unchanged).

Closes #461