### PR TITLE
feat: accessible loading spinner, bundle analyzer, Husky hooks, and .env.example [FE-265–268]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@
 # Base URL of the VeriTix backend REST API
 NEXT_PUBLIC_API_BASE_URL=http://localhost:4000/api
 
+# WebSocket server URL for real-time features
+NEXT_PUBLIC_WS_URL=ws://localhost:4000
+
 # ----- Stellar / Blockchain -----
 # Stellar network to connect to: "testnet" | "mainnet"
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
@@ -20,16 +23,38 @@ NEXT_PUBLIC_STELLAR_NETWORK=testnet
 # Horizon server URL (leave blank to use the SDK default for the chosen network)
 NEXT_PUBLIC_HORIZON_URL=
 
+# Stellar account public key for the platform escrow (server-only)
+STELLAR_PLATFORM_PUBLIC_KEY=
+
+# Stellar account secret key (server-only — NEVER prefix with NEXT_PUBLIC_)
+STELLAR_PLATFORM_SECRET_KEY=
+
 # ----- Authentication -----
 # Secret used to sign/verify server-side session tokens (server-only)
 AUTH_SECRET=replace-with-a-long-random-string
+
+# NextAuth / session configuration
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=replace-with-a-long-random-string
+
+# ----- OAuth Providers (server-only) -----
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # ----- Feature Flags -----
 # Set to "true" to enable wallet-connect flow in the UI
 NEXT_PUBLIC_ENABLE_WALLET_CONNECT=false
 
-# Enable Google OAuth sign-up/sign-in (set to "true" when backend is configured)
+# Enable Google OAuth sign-up/sign-in
 NEXT_PUBLIC_GOOGLE_AUTH_ENABLED=false
 
-# Enable Wallet-based sign-up/sign-in (set to "true" when wallet integration is ready)
+# Enable Wallet-based sign-up/sign-in
 NEXT_PUBLIC_WALLET_AUTH_ENABLED=false
+
+# ----- Analytics (optional) -----
+# Vercel Analytics / PostHog / Mixpanel token
+NEXT_PUBLIC_ANALYTICS_TOKEN=
+
+# ----- Bundle Analysis -----
+# Set to "true" and run `npm run build` to open bundle analyzer
+ANALYZE=false

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running pre-commit checks..."
+npx lint-staged

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const withPWA = require("next-pwa")({
   skipWaiting: true,
 });
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+  enabled: process.env.ANALYZE === "true",
+});
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -20,4 +25,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withPWA(nextConfig);
+export default withBundleAnalyzer(withPWA(nextConfig));

--- a/src/components/ui/LoadingSpinner.tsx
+++ b/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+interface LoadingSpinnerProps {
+  /** Accessible label for screen readers */
+  label?: string;
+  /** Visual size of the spinner */
+  size?: "sm" | "md" | "lg";
+  /** Optionally render as inline (span) instead of block (div) */
+  inline?: boolean;
+  /** Extra class names */
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "h-4 w-4 border-2",
+  md: "h-8 w-8 border-2",
+  lg: "h-12 w-12 border-4",
+};
+
+/**
+ * Accessible loading spinner that announces loading state to screen readers.
+ * Uses role="status" and aria-label so assistive technologies read the label
+ * without requiring sighted-only animation cues.
+ */
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  label = "Loading…",
+  size = "md",
+  inline = false,
+  className = "",
+}) => {
+  const Tag = inline ? "span" : "div";
+
+  return (
+    <Tag
+      role="status"
+      aria-label={label}
+      aria-live="polite"
+      className={`flex items-center justify-center ${className}`}
+    >
+      <span
+        aria-hidden="true"
+        className={`inline-block animate-spin rounded-full border-solid border-current border-r-transparent ${sizeClasses[size]}`}
+      />
+      {/* Visible fallback text for environments where CSS animation is disabled */}
+      <span className="sr-only">{label}</span>
+    </Tag>
+  );
+};
+
+export default LoadingSpinner;


### PR DESCRIPTION
## Summary

This PR resolves four developer-experience issues (FE-265 to FE-268), covering accessible UI primitives, build-size observability, commit quality enforcement, and environment variable documentation.

---

## Changes

### FE-265 — Accessible Loading Spinner (Closes #605)
- Added `src/components/ui/LoadingSpinner.tsx`
- Uses `role="status"` and `aria-label` so screen readers announce loading state without relying on animation cues
- Supports `sm`, `md`, `lg` sizes and inline/block rendering
- Includes `aria-live="polite"` and a `.sr-only` text fallback for CSS-animation-disabled environments

### FE-266 — Bundle Analyzer (Closes #606)
- Integrated `@next/bundle-analyzer` into `next.config.ts` via `withBundleAnalyzer` wrapper
- Activated only when `ANALYZE=true` — zero overhead in normal builds
- Added `ANALYZE=false` to `.env.example` with usage instructions

### FE-267 — Husky Hooks (Closes #607)
- Added `.husky/pre-commit` running `lint-staged` before every commit
- Added `.husky/commit-msg` running `commitlint` to enforce Conventional Commits
- Both hooks use `husky.sh` bootstrap for portability across platforms

### FE-268 — .env.example (Closes #608)
- Expanded `.env.example` with all required and optional variables:
  - Backend API + WebSocket URLs
  - Stellar network, Horizon URL, and server-only key placeholders
  - NextAuth URL + secret
  - Google OAuth client ID/secret
  - Feature flags, analytics token, and `ANALYZE` flag
- All server-only secrets are clearly marked to prevent accidental `NEXT_PUBLIC_` leakage

---

## Testing

Reviewer checklist:
- [ ] `<LoadingSpinner />` renders with a visible spinner and announces label via screen reader
- [ ] `ANALYZE=true npm run build` opens the bundle report in the browser
- [ ] Making a commit with a malformed message is blocked by the `commit-msg` hook
- [ ] `.env.example` covers all variables needed to run the app locally from scratch

> No application tests were added — the reviewer will validate runtime behaviour per team convention.

---

Closes #605, Closes #606, Closes #607, Closes #608