### PR TITLE
feat(charts): prior-period overlay, funnel chart, URL date params, and error boundary [FE-282–285]

### DIFF
--- a/src/components/charts/ChartErrorBoundary.tsx
+++ b/src/components/charts/ChartErrorBoundary.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React, { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  /** Optional custom fallback UI. Receives the error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  /** Callback fired when an error is caught — useful for logging. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /** Chart name shown in the default fallback UI. */
+  chartName?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary for chart components. Prevents a rendering error in one
+ * chart from crashing the entire dashboard. Provides a visual fallback with
+ * an optional retry button.
+ *
+ * Usage:
+ * ```tsx
+ * <ChartErrorBoundary chartName="Revenue Overview">
+ *   <RevenueChart />
+ * </ChartErrorBoundary>
+ * ```
+ */
+export class ChartErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+    this.reset = this.reset.bind(this);
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  reset() {
+    this.setState({ hasError: false, error: null });
+  }
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback(this.state.error, this.reset);
+      }
+
+      return (
+        <div
+          role="alert"
+          className="flex flex-col items-center justify-center gap-3 rounded-lg border border-red-200 bg-red-50 p-6 text-center"
+        >
+          <svg
+            aria-hidden="true"
+            className="h-8 w-8 text-red-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            />
+          </svg>
+          <p className="text-sm font-medium text-red-700">
+            {this.props.chartName
+              ? `Could not load "${this.props.chartName}"`
+              : "Chart failed to load"}
+          </p>
+          <p className="text-xs text-red-500">{this.state.error.message}</p>
+          <button
+            onClick={this.reset}
+            className="rounded-md bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500"
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ChartErrorBoundary;

--- a/src/components/charts/FunnelChart.tsx
+++ b/src/components/charts/FunnelChart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import {
+  FunnelChart as RechartsFunnelChart,
+  Funnel,
+  Tooltip,
+  Cell,
+  LabelList,
+  ResponsiveContainer,
+} from "recharts";
+
+export interface FunnelStage {
+  name: string;
+  value: number;
+  fill?: string;
+}
+
+interface FunnelChartProps {
+  stages: FunnelStage[];
+  height?: number;
+  valueFormatter?: (value: number) => string;
+  className?: string;
+}
+
+const DEFAULT_COLORS = [
+  "#7c3aed",
+  "#8b5cf6",
+  "#a78bfa",
+  "#c4b5fd",
+  "#ddd6fe",
+];
+
+/**
+ * Ticket-sales funnel chart showing drop-off between stages
+ * (e.g. page views → add to cart → checkout → purchase).
+ */
+export const FunnelChart: React.FC<FunnelChartProps> = ({
+  stages,
+  height = 300,
+  valueFormatter = (v) => v.toLocaleString(),
+  className = "",
+}) => {
+  const data = stages.map((stage, i) => ({
+    ...stage,
+    fill: stage.fill ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+  }));
+
+  return (
+    <div className={className} style={{ width: "100%", height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsFunnelChart>
+          <Tooltip
+            formatter={(value: number) => [valueFormatter(value), "Count"]}
+            contentStyle={{
+              borderRadius: 8,
+              border: "1px solid #e5e7eb",
+              fontSize: 13,
+            }}
+          />
+          <Funnel dataKey="value" data={data} isAnimationActive>
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.fill} />
+            ))}
+            <LabelList
+              position="right"
+              content={({ value, name }) =>
+                `${name}: ${valueFormatter(Number(value))}`
+              }
+              style={{ fontSize: 12, fill: "#374151" }}
+            />
+          </Funnel>
+        </RechartsFunnelChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default FunnelChart;

--- a/src/components/charts/PriorPeriodOverlay.tsx
+++ b/src/components/charts/PriorPeriodOverlay.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React from "react";
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+export interface PriorPeriodDataPoint {
+  label: string;
+  current: number;
+  prior: number;
+}
+
+interface PriorPeriodOverlayProps {
+  data: PriorPeriodDataPoint[];
+  currentLabel?: string;
+  priorLabel?: string;
+  valueFormatter?: (value: number) => string;
+  height?: number;
+  className?: string;
+}
+
+const defaultFormatter = (v: number) =>
+  new Intl.NumberFormat("en-NG", {
+    style: "currency",
+    currency: "NGN",
+    maximumFractionDigits: 0,
+  }).format(v);
+
+/**
+ * Overlays the current period as an Area chart with the prior period as a
+ * dashed Line for quick visual comparison.
+ */
+export const PriorPeriodOverlay: React.FC<PriorPeriodOverlayProps> = ({
+  data,
+  currentLabel = "Current Period",
+  priorLabel = "Prior Period",
+  valueFormatter = defaultFormatter,
+  height = 320,
+  className = "",
+}) => {
+  return (
+    <div className={className} style={{ width: "100%", height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart
+          data={data}
+          margin={{ top: 8, right: 24, left: 8, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 12, fill: "#6b7280" }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tickFormatter={valueFormatter}
+            tick={{ fontSize: 12, fill: "#6b7280" }}
+            axisLine={false}
+            tickLine={false}
+            width={80}
+          />
+          <Tooltip
+            formatter={(value: number, name: string) => [
+              valueFormatter(value),
+              name,
+            ]}
+            contentStyle={{
+              borderRadius: 8,
+              border: "1px solid #e5e7eb",
+              fontSize: 13,
+            }}
+          />
+          <Legend
+            wrapperStyle={{ fontSize: 13, paddingTop: 12 }}
+            iconType="square"
+          />
+          <Area
+            type="monotone"
+            dataKey="current"
+            name={currentLabel}
+            stroke="#7c3aed"
+            fill="#ede9fe"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="prior"
+            name={priorLabel}
+            stroke="#9ca3af"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default PriorPeriodOverlay;

--- a/src/hooks/useDateRangeParams.ts
+++ b/src/hooks/useDateRangeParams.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+export interface DateRange {
+  from: Date | undefined;
+  to: Date | undefined;
+}
+
+const DATE_FORMAT_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDate(value: string | null): Date | undefined {
+  if (!value || !DATE_FORMAT_RE.test(value)) return undefined;
+  const d = new Date(`${value}T00:00:00Z`);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function formatDate(date: Date | undefined): string | undefined {
+  if (!date) return undefined;
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Syncs a date range to/from URL search params (`from` and `to` keys).
+ * Falls back to `undefined` for missing or malformed values.
+ *
+ * @example
+ * const { range, setRange } = useDateRangeParams();
+ * // URL: ?from=2024-01-01&to=2024-01-31
+ */
+export function useDateRangeParams(
+  fromKey = "from",
+  toKey = "to"
+): {
+  range: DateRange;
+  setRange: (range: DateRange) => void;
+  clearRange: () => void;
+} {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const range = useMemo<DateRange>(
+    () => ({
+      from: parseDate(searchParams.get(fromKey)),
+      to: parseDate(searchParams.get(toKey)),
+    }),
+    [searchParams, fromKey, toKey]
+  );
+
+  const setRange = useCallback(
+    ({ from, to }: DateRange) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      const fromStr = formatDate(from);
+      const toStr = formatDate(to);
+
+      if (fromStr) {
+        params.set(fromKey, fromStr);
+      } else {
+        params.delete(fromKey);
+      }
+
+      if (toStr) {
+        params.set(toKey, toStr);
+      } else {
+        params.delete(toKey);
+      }
+
+      router.push(`${pathname}?${params.toString()}`);
+    },
+    [router, pathname, searchParams, fromKey, toKey]
+  );
+
+  const clearRange = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete(fromKey);
+    params.delete(toKey);
+    router.push(`${pathname}?${params.toString()}`);
+  }, [router, pathname, searchParams, fromKey, toKey]);
+
+  return { range, setRange, clearRange };
+}


### PR DESCRIPTION
## Summary

This PR delivers four analytics and charting improvements (FE-282 to FE-285): period-over-period comparison, conversion funnel visualisation, URL-synced date range filtering, and resilient error handling for chart components.

---

## Changes

### FE-282 — Prior-Period Overlay Chart (Closes #622)
- Added `src/components/charts/PriorPeriodOverlay.tsx`
- Renders current period as a filled `Area` and prior period as a dashed `Line` using Recharts `ComposedChart`
- Supports custom labels, value formatter (defaults to NGN currency), and configurable height
- Responsive via `ResponsiveContainer`

### FE-283 — Funnel Chart (Closes #623)
- Added `src/components/charts/FunnelChart.tsx`
- Uses Recharts `FunnelChart` + `Funnel` + `LabelList` for ticket-sales conversion analysis
- Accepts `FunnelStage[]` with optional per-stage `fill` colour; falls back to a purple gradient palette
- `LabelList` renders stage name + formatted value alongside each funnel segment

### FE-284 — DateRangePicker URL Params (Closes #624)
- Added `src/hooks/useDateRangeParams.ts`
- Syncs `from` / `to` dates to URL search params so ranges survive navigation and are shareable
- Validates date strings against `YYYY-MM-DD` format; malformed values are silently ignored
- Exposes `setRange` and `clearRange` helpers built with `useRouter` + `useSearchParams`

### FE-285 — ChartErrorBoundary (Closes #625)
- Added `src/components/charts/ChartErrorBoundary.tsx`
- Class-based React error boundary that catches rendering errors inside chart subtrees
- Default fallback shows chart name, error message, and a **Retry** button that resets state
- Accepts a custom `fallback` render prop and an `onError` callback for error reporting
- Prevents one broken chart from crashing the entire analytics dashboard

---

## Usage Example

```tsx
<ChartErrorBoundary chartName="Revenue Overview">
  <PriorPeriodOverlay data={periodData} />
</ChartErrorBoundary>
```

---

## Testing

Reviewer checklist:
- [ ] `PriorPeriodOverlay` renders both lines with correct colours and tooltip values
- [ ] `FunnelChart` displays stages in descending order with correct labels
- [ ] Selecting a date range via `useDateRangeParams` reflects in the URL and survives a page refresh
- [ ] Throwing inside a chart wrapped in `ChartErrorBoundary` shows the fallback, and clicking **Retry** recovers

> No application tests were added — the reviewer will validate runtime behaviour per team convention.

---

Closes #622, Closes #623, Closes #624, Closes #625