### PR TITLE
Fix Stellar blockchain schema, API auth headers, and middleware role access

### DIFF
--- a/src/lib/createEventValidation.ts
+++ b/src/lib/createEventValidation.ts
@@ -88,7 +88,7 @@ export const createEventSchema = z
     tickets: z.array(ticketSchema).min(1, "At least one ticket type is required"),
 
     // Blockchain
-    blockchainNetwork: z.enum(["ethereum", "polygon", "solana"]),
+    blockchainNetwork: z.enum(["stellar"]),
     treasuryAddress: z.string().min(1, "Treasury address is required"),
     creatorRoyalty: z.number().min(0).max(10),
 
@@ -124,20 +124,12 @@ export const createEventSchema = z
     // Treasury address format validation per network
     if (data.treasuryAddress) {
       const addr = data.treasuryAddress.trim();
-      const evmRe = /^0x[0-9a-fA-F]{40}$/;
-      const solanaRe = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-      const examples: Record<string, string> = {
-        ethereum: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
-        polygon: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
-        solana: 'So11111111111111111111111111111111111111112',
-      };
-      const valid =
-        (data.blockchainNetwork === 'solana' && solanaRe.test(addr)) ||
-        (['ethereum', 'polygon'].includes(data.blockchainNetwork) && evmRe.test(addr));
+      const stellarRe = /^G[A-Z2-7]{55}$/;
+      const valid = data.blockchainNetwork === 'stellar' && stellarRe.test(addr);
       if (!valid) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Invalid ${data.blockchainNetwork} address. Example: ${examples[data.blockchainNetwork]}`,
+          message: `Invalid ${data.blockchainNetwork} address. Example: GASW2... (56-character base32 G-address)`,
           path: ['treasuryAddress'],
         });
       }

--- a/src/lib/eventsApi.ts
+++ b/src/lib/eventsApi.ts
@@ -48,14 +48,11 @@ export async function fetchOrganizerById(id: string): Promise<Organizer | null> 
 }
 
 export async function fetchEventsByOrganizer(organizerId: string): Promise<Event[]> {
-  const events = await fetchEvents();
-  return events.filter(e => e.organizer?.name && getOrganizerIdFromName(e.organizer.name) === organizerId);
-}
-
-function getOrganizerIdFromName(name: string): string {
-  const nameToId: Record<string, string> = {
-    "Rhythm Nation Collective": "rhythm-nation-collective",
-    "Beat Collective": "beat-collective",
-  };
-  return nameToId[name] ?? name.toLowerCase().replace(/\s+/g, '-');
+  if (!API_BASE) {
+    const events = await fetchEvents();
+    return events.filter(e => e.organizer?.id === organizerId);
+  }
+  const res = await fetch(`${API_BASE}/events?organizerId=${encodeURIComponent(organizerId)}`, { next: { revalidate: 60 } });
+  if (!res.ok) throw new Error("Failed to fetch organizer events");
+  return res.json() as Promise<Event[]>;
 }

--- a/src/lib/ticketVerification.ts
+++ b/src/lib/ticketVerification.ts
@@ -1,5 +1,23 @@
 // FE-082: Real ticket check-in API integration for verification flow
 
+import { getToken } from "@/lib/auth";
+
+export class AuthError extends Error {
+  constructor(message = "Authentication required. Please log in to verify tickets.") {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+function getAuthHeaders(): Record<string, string> {
+  const token = getToken();
+  if (!token) throw new AuthError();
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
 export interface TicketVerificationResult {
   valid: boolean;
   alreadyUsed?: boolean;
@@ -12,9 +30,12 @@ export interface TicketVerificationResult {
 export async function verifyTicket(code: string): Promise<TicketVerificationResult> {
   const res = await fetch("/api/tickets/verify", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: getAuthHeaders(),
     body: JSON.stringify({ code }),
   });
+  if (res.status === 401) {
+    throw new AuthError("Session expired. Please log in again.");
+  }
   if (!res.ok) {
     return { valid: false, errorMessage: "Verification service unavailable. Please try again." };
   }
@@ -24,9 +45,12 @@ export async function verifyTicket(code: string): Promise<TicketVerificationResu
 export async function checkInTicket(code: string): Promise<{ success: boolean; message: string }> {
   const res = await fetch("/api/tickets/check-in", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: getAuthHeaders(),
     body: JSON.stringify({ code }),
   });
+  if (res.status === 401) {
+    throw new AuthError("Session expired. Please log in again.");
+  }
   if (!res.ok) return { success: false, message: "Check-in failed. Please try again." };
   return res.json();
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { canAccessVerificationTools } from "@/lib/verificationAccess";
+import type { UserRole } from "@/lib/verificationAccess";
+
+function decodeUserRole(token: string): UserRole | null {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return (payload.role ?? null) as UserRole | null;
+  } catch {
+    return null;
+  }
+}
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -23,9 +33,9 @@ export function middleware(request: NextRequest) {
   }
 
   if (pathname.startsWith("/verify")) {
-    const roleCookie = request.cookies.get("user_role")?.value as
-      | "attendee" | "organizer" | "staff" | "admin" | null;
-    if (!canAccessVerificationTools(roleCookie ?? null)) {
+    const roleFromCookie = request.cookies.get("user_role")?.value as UserRole | null;
+    const role = roleFromCookie ?? decodeUserRole(token);
+    if (!canAccessVerificationTools(role)) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
   }


### PR DESCRIPTION
## Changes

### Fix eventsApi fetchEventsByOrganizer (Closes #534)
- Replaced client-side filtering with a targeted API call to \GET /events?organizerId={id}\
- Removed the hardcoded \
ameToId\ map and \getOrganizerIdFromName\ helper
- Mock fallback retained when \API_BASE\ is empty

### Fix blockchainNetwork Zod schema for Stellar (Closes #533)
- Changed \lockchainNetwork\ enum from \['ethereum', 'polygon', 'solana']\ to \['stellar']\
- Updated treasury address validation to accept Stellar account IDs (G-addresses, 56 chars, base32)
- Zod error message now shows a valid Stellar address example

### Add Authorization header to ticket verification (Closes #532)
- Both \erifyTicket\ and \checkInTicket\ now include \Authorization: Bearer <token>\ header
- Functions throw \AuthError\ when no token is available instead of making unauthenticated requests
- 401 responses from the server now surface a specific authentication error

### Fix middleware user_role cookie access (Closes #531)
- Middleware now decodes the JWT from the \uth_token\ cookie to read the role claim directly
- Falls back to \user_role\ cookie if present, otherwise uses JWT decoding
- Verified staff and organizer roles can now access \/verify\ without being redirected