### PR TITLE
Add ARIA labels, high-contrast mode, and auth e2e test

### DIFF
--- a/e2e/auth-full.spec.ts
+++ b/e2e/auth-full.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * E2E test: Full auth flow — register, verify OTP, login, and logout (FE-228).
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Auth Flow", () => {
+  test("register with valid credentials shows verify-email page", async ({ page }) => {
+    // Mock registration endpoint
+    await page.route("**/api/auth/register", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Verification email sent" }),
+      })
+    );
+
+    await page.goto("/sign-up");
+    await page.waitForLoadState("networkidle");
+
+    // Fill registration form
+    const firstNameInput = page.getByLabel(/first name/i);
+    if (await firstNameInput.isVisible()) {
+      await firstNameInput.fill("John");
+      await page.getByLabel(/last name/i).fill("Doe");
+      await page.getByLabel(/username/i).fill("johndoe");
+      await page.getByLabel(/email/i).fill("john@example.com");
+      await page.getByLabel(/password/i).fill("SecureP@ss123");
+
+      const submitBtn = page.getByRole("button", { name: /sign up|create account/i });
+      await submitBtn.click();
+
+      // Should redirect to verify-email page
+      await page.waitForURL("**/verify-email**", { timeout: 10000 });
+      expect(page.url()).toContain("verify-email");
+    }
+  });
+
+  test("login with correct credentials redirects to dashboard", async ({ page }) => {
+    // Mock login endpoint
+    await page.route("**/api/auth/login", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          token: "mock-jwt-token",
+          user: { id: "u1", email: "test@example.com", name: "Test User" },
+        }),
+      })
+    );
+
+    // Mock auth check
+    await page.route("**/api/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "u1", email: "test@example.com", name: "Test User" }),
+      })
+    );
+
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByLabel(/email/i).fill("test@example.com");
+    await page.getByLabel(/password/i).fill("password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    // Should redirect to dashboard
+    await page.waitForURL("**/dashboard**", { timeout: 10000 });
+    expect(page.url()).toContain("/dashboard");
+  });
+
+  test("login with wrong password shows inline error", async ({ page }) => {
+    await page.route("**/api/auth/login", (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Invalid credentials" }),
+      })
+    );
+
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByLabel(/email/i).fill("test@example.com");
+    await page.getByLabel(/password/i).fill("wrongpassword");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    // Should show error message
+    await expect(page.getByText(/invalid credentials|incorrect/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("navigate to /dashboard without auth redirects to /login", async ({ page }) => {
+    await page.goto("/dashboard");
+    // Should redirect to login with next param
+    await page.waitForURL("**/login**", { timeout: 10000 });
+    expect(page.url()).toContain("/login");
+    expect(page.url()).toContain("next=%2Fdashboard");
+  });
+
+  test("login with ?next param redirects to correct page", async ({ page }) => {
+    await page.route("**/api/auth/login", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          token: "mock-jwt-token",
+          user: { id: "u1", email: "test@example.com" },
+        }),
+      })
+    );
+
+    await page.route("**/api/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "u1", email: "test@example.com" }),
+      })
+    );
+
+    await page.goto("/login?next=%2Fdashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByLabel(/email/i).fill("test@example.com");
+    await page.getByLabel(/password/i).fill("password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await page.waitForURL("**/dashboard**", { timeout: 10000 });
+    expect(page.url()).toContain("/dashboard");
+  });
+
+  test("logout redirects to home", async ({ page }) => {
+    // Set up authenticated state
+    await page.route("**/api/auth/me", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "u1", email: "test@example.com" }),
+      })
+    );
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Look for logout button/link
+    const logoutBtn = page.getByRole("button", { name: /log ?out|sign ?out/i });
+    const logoutLink = page.getByRole("link", { name: /log ?out|sign ?out/i });
+
+    if (await logoutBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await logoutBtn.click();
+    } else if (await logoutLink.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await logoutLink.click();
+    }
+
+    // Should redirect to home
+    await page.waitForURL("/", { timeout: 5000 });
+    expect(page.url()).toMatch(/\/$/);
+  });
+});

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -56,8 +56,12 @@ function TrendingEventCard({ event }: { event: Event }) {
           {event.category}
         </span>
         <div className="flex items-center gap-3">
-          <Share2 size={16} />
-          <Heart size={16} />
+          <button type="button" aria-label="Share event" className="p-0 bg-transparent border-0 cursor-pointer">
+            <Share2 size={16} />
+          </button>
+          <button type="button" aria-label="Add to favourites" className="p-0 bg-transparent border-0 cursor-pointer">
+            <Heart size={16} />
+          </button>
         </div>
       </div>
 
@@ -284,7 +288,7 @@ export default function Home() {
                   placeholder="Search events, artists..."
                   value={searchQ}
                   onChange={(e) => setSearchQ(e.target.value)}
-                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/40"
+                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/60"
                   aria-label="Event name or keyword"
                 />
               </div>
@@ -295,7 +299,7 @@ export default function Home() {
                   placeholder="Location..."
                   value={searchLocation}
                   onChange={(e) => setSearchLocation(e.target.value)}
-                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/40"
+                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/60"
                   aria-label="Event location"
                 />
               </div>
@@ -306,7 +310,7 @@ export default function Home() {
                   placeholder="Date..."
                   value={searchDate}
                   onChange={(e) => setSearchDate(e.target.value)}
-                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/40"
+                  className="w-full bg-transparent text-sm focus:outline-none text-white placeholder:text-white/60"
                   aria-label="Event date"
                 />
               </div>
@@ -410,8 +414,12 @@ export default function Home() {
                     {event.category}
                   </span>
                   <div className="flex items-center gap-3">
-                    <Share2 size={16} />
-                    <Heart size={16} />
+                    <button type="button" aria-label="Share event" className="p-0 bg-transparent border-0 cursor-pointer">
+                      <Share2 size={16} />
+                    </button>
+                    <button type="button" aria-label="Add to favourites" className="p-0 bg-transparent border-0 cursor-pointer">
+                      <Heart size={16} />
+                    </button>
                   </div>
                 </div>
 

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -236,3 +236,31 @@ body {
     rgba(33, 212, 255, 1) 100%
   );
 }
+
+/* High contrast mode for WCAG AA compliance */
+@media (prefers-contrast: more) {
+  .text-white\/40 {
+    color: rgba(255, 255, 255, 0.85) !important;
+  }
+  .text-white\/50 {
+    color: rgba(255, 255, 255, 0.9) !important;
+  }
+  .text-white\/60 {
+    color: rgba(255, 255, 255, 0.92) !important;
+  }
+  .text-white\/70 {
+    color: rgba(255, 255, 255, 0.95) !important;
+  }
+  .text-gray-400 {
+    color: rgba(255, 255, 255, 0.9) !important;
+  }
+  .text-gray-500 {
+    color: rgba(255, 255, 255, 0.85) !important;
+  }
+  .bg-white\/5 {
+    background-color: rgba(255, 255, 255, 0.12) !important;
+  }
+  .border-white\/10 {
+    border-color: rgba(255, 255, 255, 0.3) !important;
+  }
+}


### PR DESCRIPTION
## Changes
closes #558
### Add ARIA labels to all icon-only buttons (Closes #486)
- Added aria-label="Share event" to Share2 icon buttons on landing page
- Added aria-label="Add to favourites" to Heart icon buttons on landing page
- Modal close buttons already had aria-label="Close modal" in the base Modal component
- Copy buttons in StellarPaymentInstructions already had aria-label

### Add high-contrast mode support (Closes #487)
- Added prefers-contrast: more media query in global.css
- Overrides text-white/40 through text-white/70 to higher opacity values
- Overrides gray text colors for better contrast
- Upgraded search input placeholders from text-white/40 to text-white/60 for better baseline contrast
- Added border and background overrides for cards and separators

### Add Playwright e2e test for auth flow (Closes #490)
- Register with valid credentials shows verify-email page
- Login with correct credentials redirects to dashboard
- Login with wrong password shows inline error
- Navigate to /dashboard without auth redirects to /login with next param
- Login with ?next param redirects to correct page
- Logout redirects to home
