### PR TITLE
feat(dashboard): Revenue trend memoization, visual testing, lib coverage & MSW ticket contracts

### DIFF
--- a/e2e/dashboard-visual.spec.ts
+++ b/e2e/dashboard-visual.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard Visual Regression Tests", () => {
+  const viewports = [
+    { width: 375, height: 667, name: "mobile-375px" },
+    { width: 768, height: 1024, name: "tablet-768px" },
+    { width: 1280, height: 800, name: "desktop-1280px" },
+  ];
+
+  for (const vp of viewports) {
+    test(`dashboard layout visual check at ${vp.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.emulateMedia({ reducedMotion: "reduce" });
+      await page.goto("/dashboard");
+      await expect(page).toHaveScreenshot(`dashboard-${vp.name}.png`, {
+        maxDiffPixelRatio: 0.001,
+      });
+    });
+  }
+});

--- a/src/__tests__/lib-coverage.test.ts
+++ b/src/__tests__/lib-coverage.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "../lib/cn";
+import { formatCurrency } from "../lib/currencyFormat";
+import { buildLocationString } from "../lib/locationFields";
+import { getInventoryStatusLabel } from "../lib/inventoryStatus";
+import { CONTACT_CONFIG } from "../lib/contactConfig";
+import { getGalleryLimitMessage, MAX_GALLERY_IMAGES } from "../lib/galleryLimit";
+
+describe("src/lib utilities coverage", () => {
+  it("tests cn helper", () => {
+    expect(cn("bg-red-500", undefined, "text-white")).toBe("bg-red-500 text-white");
+  });
+
+  it("tests currencyFormat helper", () => {
+    expect(formatCurrency(100)).toContain("100");
+  });
+
+  it("tests locationFields helper", () => {
+    expect(buildLocationString("123 Main St", "City", "State")).toBe("123 Main St, City, State");
+    expect(buildLocationString("", "", "")).toBe("");
+  });
+
+  it("tests inventoryStatus helper", () => {
+    expect(getInventoryStatusLabel(0)).toBe("Sold Out");
+    expect(getInventoryStatusLabel(5)).toBe("Low Stock");
+    expect(getInventoryStatusLabel(50)).toBe("In Stock");
+  });
+
+  it("tests contactConfig", () => {
+    expect(CONTACT_CONFIG.supportEmail).toBeDefined();
+  });
+
+  it("tests galleryLimit helper", () => {
+    expect(MAX_GALLERY_IMAGES).toBeGreaterThan(0);
+    expect(getGalleryLimitMessage(MAX_GALLERY_IMAGES)).toContain("Maximum");
+  });
+});

--- a/src/__tests__/msw-ticket-contract.test.ts
+++ b/src/__tests__/msw-ticket-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { setupServer } from "msw/node";
+import { ticketHandlers } from "../mocks/ticketHandlers";
+
+const server = setupServer(...ticketHandlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("Ticket API MSW Contract Tests", () => {
+  it("POST /api/tickets/verify returns valid TicketVerificationResult shape", async () => {
+    const res = await fetch("/api/tickets/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ticketId: "t-100" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.valid).toBe(true);
+    expect(data.ticketId).toBe("t-100");
+    expect(data.status).toBe("VALID");
+  });
+
+  it("POST /api/tickets/verify handles error response shape", async () => {
+    const res = await fetch("/api/tickets/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ticketId: "invalid" }),
+    });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Ticket not found");
+  });
+
+  it("POST /api/tickets/check-in returns success shape", async () => {
+    const res = await fetch("/api/tickets/check-in", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ticketId: "t-100" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.checkInTime).toBeDefined();
+  });
+});

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -82,25 +82,29 @@ export default function DashboardPage() {
   const payoutsQueued = data?.payoutsQueued ?? 0;
   const nextSettlementDays = data?.nextSettlementDays ?? 0;
 
-  const revenueTrend = (() => {
+  const { revenueTrend, trendText, trendColor } = useMemo(() => {
     const rev = data?.revenue ?? [];
-    if (rev.length < 14) return null;
+    if (rev.length < 14) {
+      return {
+        revenueTrend: null,
+        trendText: "Insufficient data for trend",
+        trendColor: "text-gray-500",
+      };
+    }
     const currentWeek = rev.slice(-7).reduce((sum, d) => sum + d.revenue, 0);
     const lastWeek = rev.slice(-14, -7).reduce((sum, d) => sum + d.revenue, 0);
-    if (lastWeek === 0) return null;
-    return ((currentWeek - lastWeek) / lastWeek) * 100;
-  })();
-
-  const trendText =
-    revenueTrend === null
-      ? "Insufficient data for trend"
-      : `Trending by ${Math.abs(revenueTrend).toFixed(1)}% ${revenueTrend >= 0 ? "↗️" : "↘️"} this week`;
-  const trendColor =
-    revenueTrend === null
-      ? "text-gray-500"
-      : revenueTrend >= 0
-        ? "text-emerald-400"
-        : "text-red-400";
+    if (lastWeek === 0) {
+      return {
+        revenueTrend: null,
+        trendText: "Insufficient data for trend",
+        trendColor: "text-gray-500",
+      };
+    }
+    const trend = ((currentWeek - lastWeek) / lastWeek) * 100;
+    const text = `Trending by ${Math.abs(trend).toFixed(1)}% ${trend >= 0 ? "↗️" : "↘️"} this week`;
+    const color = trend >= 0 ? "text-emerald-400" : "text-red-400";
+    return { revenueTrend: trend, trendText: text, trendColor: color };
+  }, [data?.revenue]);
 
   const eventImgs =
     data?.events?.slice(0, 4).map((e) => ({

--- a/src/mocks/ticketHandlers.ts
+++ b/src/mocks/ticketHandlers.ts
@@ -1,0 +1,30 @@
+import { http, HttpResponse } from "msw";
+
+export const ticketHandlers = [
+  http.post("/api/tickets/verify", async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { ticketId?: string };
+    if (body.ticketId === "invalid") {
+      return HttpResponse.json({ error: "Ticket not found" }, { status: 404 });
+    }
+    return HttpResponse.json({
+      valid: true,
+      ticketId: body.ticketId || "t-123",
+      eventName: "Veritix Launch Party",
+      attendeeName: "Alice Smith",
+      status: "VALID",
+      timestamp: new Date().toISOString(),
+    });
+  }),
+
+  http.post("/api/tickets/check-in", async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { ticketId?: string };
+    if (body.ticketId === "used") {
+      return HttpResponse.json({ error: "Ticket already checked in" }, { status: 400 });
+    }
+    return HttpResponse.json({
+      success: true,
+      ticketId: body.ticketId || "t-123",
+      checkInTime: new Date().toISOString(),
+    });
+  }),
+];


### PR DESCRIPTION
This PR improves dashboard rendering performance, adds e2e visual regression tests, expands unit test coverage, and implements MSW contract testing.

### Changes
- **FE-234**: Memoized  calculation using  (#574).
- **FE-233**: Added Playwright visual regression tests at 375px, 768px, and 1280px viewports with reduced motion emulation (#573).
- **FE-232**: Expanded  test coverage to achieve >= 80% line coverage (#572).
- **FE-231**: Created MSW handlers and contract tests for  and  (#571).

Closes #574
Closes #573
Closes #572
Closes #571