### PR TITLE
feat(organizer): Post-event summary, print ticket layout, unverified account banner & order limits

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -264,3 +264,13 @@ body {
     border-color: rgba(255, 255, 255, 0.3) !important;
   }
 }
+
+@media print {
+  nav, header, sidebar, footer, .print\:hidden {
+    display: none !important;
+  }
+  body {
+    background: white !important;
+    color: black !important;
+  }
+}

--- a/src/components/dashboard/UnverifiedBanner.tsx
+++ b/src/components/dashboard/UnverifiedBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { HiExclamation, HiX } from 'react-icons/hi';
+
+export default function UnverifiedBanner({ isVerified }: { isVerified: boolean }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  if (isVerified || dismissed) return null;
+
+  const handleResend = async () => {
+    setLoading(true);
+    try {
+      await fetch('/api/auth/resend-verification', { method: 'POST' });
+      setSent(true);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-amber-500/15 border border-amber-500/30 rounded-xl p-4 flex items-center justify-between text-amber-200 text-sm">
+      <div className="flex items-center gap-3">
+        <HiExclamation className="w-5 h-5 text-amber-400 shrink-0" />
+        <span>
+          {sent
+            ? 'Verification email sent! Please check your inbox.'
+            : 'Your account email is unverified. Please verify your email to unlock all feature access.'}
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        {!sent && (
+          <button
+            onClick={handleResend}
+            disabled={loading}
+            className="px-3 py-1 text-xs font-semibold bg-amber-500 text-black hover:bg-amber-400 rounded-lg transition-colors"
+          >
+            {loading ? 'Sending...' : 'Resend Email'}
+          </button>
+        )}
+        <button
+          onClick={() => setDismissed(true)}
+          className="p-1 hover:text-white transition-colors"
+          aria-label="Dismiss banner"
+        >
+          <HiX className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/TicketQuantitySelector.tsx
+++ b/src/components/events/TicketQuantitySelector.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  pricePerTicket: number;
+  maxPerOrder?: number;
+  onQuantityChange?: (qty: number) => void;
+}
+
+export default function TicketQuantitySelector({ pricePerTicket, maxPerOrder = 10, onQuantityChange }: Props) {
+  const [qty, setQty] = useState(1);
+
+  const updateQty = (newQty: number) => {
+    const valid = Math.max(1, Math.min(maxPerOrder, newQty));
+    setQty(valid);
+    if (onQuantityChange) onQuantityChange(valid);
+  };
+
+  const totalPrice = qty * pricePerTicket;
+
+  return (
+    <div className="space-y-3 p-4 rounded-xl border border-white/10 bg-[#101428]">
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-medium text-gray-300">Select Quantity</span>
+        <div className="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg p-1">
+          <button
+            onClick={() => updateQty(qty - 1)}
+            disabled={qty <= 1}
+            className="px-2.5 py-1 text-sm font-bold text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-white/10 rounded"
+          >
+            -
+          </button>
+          <span className="text-sm font-bold text-white px-2">{qty}</span>
+          <button
+            onClick={() => updateQty(qty + 1)}
+            disabled={qty >= maxPerOrder}
+            className="px-2.5 py-1 text-sm font-bold text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-white/10 rounded"
+          >
+            +
+          </button>
+        </div>
+      </div>
+      <div className="flex justify-between items-center border-t border-white/10 pt-3">
+        <span className="text-xs text-gray-400">Total Price</span>
+        <span className="text-lg font-bold text-[#6B8CFF]">${totalPrice.toFixed(2)}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organizer/EventSummary.tsx
+++ b/src/components/organizer/EventSummary.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+export interface SummaryProps {
+  eventName: string;
+  ticketsSold: number;
+  checkedIn: number;
+}
+
+export default function EventSummary({ eventName, ticketsSold, checkedIn }: SummaryProps) {
+  const noShows = Math.max(0, ticketsSold - checkedIn);
+  const rate = ticketsSold > 0 ? ((checkedIn / ticketsSold) * 100).toFixed(1) : '0';
+
+  const handleExportPDF = () => {
+    window.print();
+  };
+
+  return (
+    <div className="p-6 rounded-xl border border-white/10 bg-[#101428] text-white space-y-6">
+      <div className="flex justify-between items-center border-b border-white/10 pb-4">
+        <div>
+          <h2 className="text-xl font-bold">{eventName} - Post Event Summary</h2>
+          <p className="text-xs text-gray-400">Final attendance & check-in metrics</p>
+        </div>
+        <button
+          onClick={handleExportPDF}
+          className="px-4 py-2 text-xs font-semibold bg-blue-600 hover:bg-blue-500 rounded-lg transition-colors"
+        >
+          Export Summary (PDF)
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="p-4 rounded-lg bg-white/5 border border-white/5">
+          <span className="text-xs text-gray-400">Tickets Sold</span>
+          <p className="text-2xl font-bold text-white pt-1">{ticketsSold}</p>
+        </div>
+        <div className="p-4 rounded-lg bg-white/5 border border-white/5">
+          <span className="text-xs text-gray-400">Checked In</span>
+          <p className="text-2xl font-bold text-emerald-400 pt-1">{checkedIn}</p>
+        </div>
+        <div className="p-4 rounded-lg bg-white/5 border border-white/5">
+          <span className="text-xs text-gray-400">No Shows</span>
+          <p className="text-2xl font-bold text-amber-400 pt-1">{noShows}</p>
+        </div>
+        <div className="p-4 rounded-lg bg-white/5 border border-white/5">
+          <span className="text-xs text-gray-400">Check-in Rate</span>
+          <p className="text-2xl font-bold text-blue-400 pt-1">{rate}%</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tickets/TicketPass.tsx
+++ b/src/components/tickets/TicketPass.tsx
@@ -121,13 +121,23 @@ export function TicketPass({ ticket, onTransfer }: TicketPassProps) {
         <div className="bg-[#1a1f3a] p-3 rounded-xl">
           <QRCode ref={qrRef} value={ticket.ticketCode} />
         </div>
-        <button
-          onClick={handleDownloadQR}
-          className="text-xs text-[#6B8CFF] hover:text-[#4D21FF] underline transition-colors"
-          aria-label="Download QR code"
-        >
-          Download QR
-        </button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleDownloadQR}
+            className="text-xs text-[#6B8CFF] hover:text-[#4D21FF] underline transition-colors"
+            aria-label="Download QR code"
+          >
+            Download QR
+          </button>
+          <span className="text-gray-600 text-xs">|</span>
+          <button
+            onClick={() => window.print()}
+            className="text-xs text-[#6B8CFF] hover:text-[#4D21FF] underline transition-colors print:hidden"
+            aria-label="Print Ticket"
+          >
+            Print Ticket
+          </button>
+        </div>
       </div>
 
       {/* Ticket code */}


### PR DESCRIPTION
This PR adds post-event summary screens, ticket printing capabilities, email verification notifications, and ticket order quantity restrictions.

### Changes
- **FE-249**: Created  component with metrics and PDF export (#589).
- **FE-248**: Added print-friendly layout and  rules for  (#588).
- **FE-247**: Added  for unverified accounts with resend CTA (#587).
- **FE-246**: Created  with  bounds (#586).

Closes #589
Closes #588
Closes #587
Closes #586