### PR TITLE
chore(ci): add Prettier config and enforce format checks in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check code formatting
+        run: npm run format:check
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -56,7 +75,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, type-check]
+    needs: [format-check, lint, type-check]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+build
+dist
+coverage
+public
+*.min.js
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "printWidth": 90,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
# 🎯 Summary

closes #559

Establishes project-wide formatting standards via Prettier to eliminate trivial style diffs in PR reviews. Adds formatting scripts to `package.json`, updates CI to fail on unformatted code, and formats all existing `src/` files in a single cleanup commit.

---

## 🛠️ Summary of Key Changes
* **`.prettierrc`**: Added project-wide formatting rules (single quotes, trailing commas, 2-space indentation).
* **`.prettierignore`**: Added standard build artifact and dependency ignores.
* **`package.json`**: Added `format` (`prettier --write`) and `format:check` (`prettier --check`) scripts.
* **`.github/workflows/ci.yml`**: Added `npm run format:check` to the CI pipeline.
* **Codebase Alignment**: Formatted existing files under `src/`.

---

## 🧪 Testing & Verification

```bash
# Verify formatting check passes
npm run format:check