### PR TITLE
Enforce alias imports and add session analytics coverage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,22 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../", "../../", "../../../", "../../../../"],
+              message:
+                "Use the @/ alias for imports that cross directory boundaries.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 const withPWA = require("next-pwa")({
   dest: "public",
   disable: process.env.NODE_ENV === "development",
@@ -50,6 +52,14 @@ const nextConfig = {
         headers: securityHeaders,
       },
     ];
+  },
+  webpack(config) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@": path.join(__dirname, "src"),
+    };
+
+    return config;
   },
   images: {
     remotePatterns: [

--- a/src/__tests__/login-session-dashboard-flow.test.tsx
+++ b/src/__tests__/login-session-dashboard-flow.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "react-toastify";
+import { getToken, loginUser, logout } from "@/lib/auth";
+import ProtectedLayout from "@/app/(protected)/layout";
+import DashboardPage from "@/app/(protected)/dashboard/page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    loginUser: vi.fn(),
+    getToken: vi.fn(),
+    logout: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useAuthState", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useSession")>("@/hooks/useSession");
+  return {
+    useAuthState: () => {
+      actual.useSession();
+      return { isLoading: false, isAuthenticated: true };
+    },
+  };
+});
+
+vi.mock("@/hooks/useOrganizerAnalytics", () => ({
+  useOrganizerAnalytics: () => ({
+    data: {
+      totalEvents: 1,
+      totalTicketsSold: 100,
+      totalRevenue: 1000,
+      totalEarned: 1000,
+      payoutsQueued: 0,
+      nextSettlementDays: 2,
+      checkInsLive: false,
+      revenue: [],
+      performance: [],
+      ticketBreakdown: [],
+      demographics: {
+        region: [],
+        deviceType: [],
+        referralSource: [],
+      },
+      events: [],
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
+describe("login to dashboard session flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn(), replace: vi.fn() } as never);
+    vi.mocked(useSearchParams).mockReturnValue({ get: vi.fn().mockReturnValue(null) } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stores the token on login and renders the dashboard after session validation", async () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push, replace: vi.fn() } as never);
+    vi.mocked(getToken).mockReturnValue("valid-token");
+    vi.mocked(loginUser).mockResolvedValue({
+      token: "valid-token",
+      user: { id: "u-1", email: "user@example.com" },
+    });
+
+    await loginUser({ email: "user@example.com", password: "password123" });
+    expect(getToken()).toBe("valid-token");
+
+    render(
+      <ProtectedLayout>
+        <DashboardPage />
+      </ProtectedLayout>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Create, Manage and Control your events efficiently/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the expired-session toast and redirects when the token is expired", async () => {
+    const replace = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn(), replace } as never);
+    vi.mocked(getToken).mockReturnValue("expired-token");
+
+    render(<ProtectedLayout><DashboardPage /></ProtectedLayout>);
+
+    await waitFor(() => {
+      expect(toast.warn).toHaveBeenCalledWith(
+        "Your session has expired. Please sign in again.",
+        expect.objectContaining({ toastId: "session-expired" }),
+      );
+    });
+    expect(replace).toHaveBeenCalledWith("/login?expired=1");
+    expect(logout).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/useOrganizerAnalytics.test.ts
+++ b/src/__tests__/useOrganizerAnalytics.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useOrganizerAnalytics, type OrganizerAnalytics } from "@/hooks/useOrganizerAnalytics";
 
+vi.mock("swr", () => ({
+  default: vi.fn(),
+}));
+
 const mockData: OrganizerAnalytics = {
   revenue: [{ day: "Mon", revenue: 5000 }],
   performance: [{ day: "Mon", value: 3000 }],
@@ -22,55 +26,50 @@ const mockData: OrganizerAnalytics = {
 describe("useOrganizerAnalytics", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("starts in loading state", () => {
-    vi.mocked(fetch).mockReturnValue(new Promise(() => {})); // never resolves
+  it("returns the loading state while the request is pending", async () => {
+    const swr = await import("swr");
+    vi.mocked(swr.default).mockReturnValue({ data: undefined, error: undefined, isLoading: true });
+
     const { result } = renderHook(() => useOrganizerAnalytics());
     expect(result.current.loading).toBe(true);
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBeNull();
   });
 
-  it("returns data on successful fetch", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    } as Response);
+  it("returns correctly shaped analytics data on success", async () => {
+    const swr = await import("swr");
+    vi.mocked(swr.default).mockReturnValue({ data: mockData, error: undefined, isLoading: false });
 
-    const { result } = renderHook(() => useOrganizerAnalytics());
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
+    const { result } = renderHook(() => useOrganizerAnalytics({ organizerId: "org-1" }));
 
     expect(result.current.data).toEqual(mockData);
     expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
   });
 
-  it("sets error when API returns non-ok response", async () => {
-    vi.mocked(fetch).mockResolvedValue({
-      ok: false,
-    } as Response);
+  it("does not request analytics when organizerId is missing", async () => {
+    const swr = await import("swr");
+    vi.mocked(swr.default).mockReturnValue({ data: null, error: undefined, isLoading: false });
+
+    renderHook(() => useOrganizerAnalytics());
+    expect(swr.default).toHaveBeenCalledWith(null, expect.any(Function), expect.any(Object));
+  });
+
+  it("surfaces API errors from the hook", async () => {
+    const swr = await import("swr");
+    vi.mocked(swr.default).mockReturnValue({ data: null, error: new Error("Failed to fetch analytics"), isLoading: false });
 
     const { result } = renderHook(() => useOrganizerAnalytics());
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBe("Failed to fetch analytics");
-  });
-
-  it("sets error when fetch throws a network error", async () => {
-    vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
-
-    const { result } = renderHook(() => useOrganizerAnalytics());
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-
-    expect(result.current.data).toBeNull();
-    expect(result.current.error).toBe("Network error");
+    expect(result.current.loading).toBe(false);
   });
 });

--- a/src/__tests__/useSession-token-utils.test.ts
+++ b/src/__tests__/useSession-token-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { getTokenExpiry, isTokenExpired, msUntilExpiry } from "@/hooks/useSession";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+vi.mock("react-toastify", () => ({
+  toast: { warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getToken: vi.fn(),
+  logout: vi.fn(),
+}));
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.sig`;
+}
+
+describe("useSession token helpers", () => {
+  it("returns true for a valid token when the expiry is in the past", () => {
+    const expired = makeToken({ exp: Math.floor(Date.now() / 1000) - 60 });
+    expect(isTokenExpired(expired)).toBe(true);
+  });
+
+  it("returns false for a token that is still valid", () => {
+    const active = makeToken({ exp: Math.floor(Date.now() / 1000) + 600 });
+    expect(isTokenExpired(active)).toBe(false);
+  });
+
+  it("returns true for malformed or missing tokens", () => {
+    expect(isTokenExpired("not-a-jwt")).toBe(true);
+    expect(isTokenExpired("")).toBe(true);
+  });
+
+  it("extracts the expiry in milliseconds for a valid JWT", () => {
+    const expSec = Math.floor(Date.now() / 1000) + 600;
+    const token = makeToken({ exp: expSec });
+
+    expect(getTokenExpiry(token)).toBe(expSec * 1000);
+  });
+
+  it("returns null for invalid JWT payloads", () => {
+    expect(getTokenExpiry("bad-token")).toBeNull();
+    expect(getTokenExpiry(makeToken({ sub: "user-1" }))).toBeNull();
+  });
+
+  it("returns positive, zero, and negative remaining time values", () => {
+    const future = Math.floor(Date.now() / 1000) + 60;
+    const past = Math.floor(Date.now() / 1000) - 60;
+
+    expect(msUntilExpiry(makeToken({ exp: future }))).toBeGreaterThan(0);
+    expect(msUntilExpiry(makeToken({ exp: Math.floor(Date.now() / 1000) }))).toBeLessThanOrEqual(0);
+    expect(msUntilExpiry(makeToken({ exp: past }))).toBeLessThan(0);
+  });
+});

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,8 +4,8 @@ import {
   FieldValues,
   FieldPath,
 } from "react-hook-form";
-import { cn } from "../../lib/cn";
-import usePasswordToggle from "../../hooks/usePasswordToggle";
+import { cn } from "@/lib/cn";
+import usePasswordToggle from "@/hooks/usePasswordToggle";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa6";
 import Link from "next/link";
 

--- a/src/hooks/useOrganizerAnalytics.ts
+++ b/src/hooks/useOrganizerAnalytics.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import useSWR from "swr";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -57,47 +57,31 @@ interface Options {
 }
 
 export function useOrganizerAnalytics(options: Options = {}) {
-  const [data, setData] = useState<OrganizerAnalytics | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
   const { organizerId, from, to } = options;
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
+  const params = new URLSearchParams();
+  if (organizerId) params.set("organizerId", organizerId);
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const qs = params.toString() ? `?${params.toString()}` : "";
 
-    const params = new URLSearchParams();
-    if (organizerId) params.set("organizerId", organizerId);
-    if (from) params.set("from", from);
-    if (to) params.set("to", to);
-    const qs = params.toString() ? `?${params.toString()}` : "";
+  const key = organizerId || from || to ? `/api/organizer/analytics${qs}` : null;
 
-    fetch(`/api/organizer/analytics${qs}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to fetch analytics");
-        return res.json() as Promise<OrganizerAnalytics>;
-      })
-      .then((json) => {
-        if (!cancelled) {
-          setData(json);
-          setLoading(false);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Unknown error");
-          setLoading(false);
-        }
-      });
+  const { data, error, isLoading } = useSWR<OrganizerAnalytics | null>(
+    key,
+    async () => {
+      const res = await fetch(`/api/organizer/analytics${qs}`);
+      if (!res.ok) throw new Error("Failed to fetch analytics");
+      return (await res.json()) as OrganizerAnalytics;
+    },
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  );
 
-    return () => {
-      cancelled = true;
-    };
-  }, [organizerId, from, to]);
-
-  return { data, loading, error };
+  return {
+    data: data ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error.message : null,
+  };
 }
 
 // ─── Selectors ────────────────────────────────────────────────────────────────

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -37,7 +37,7 @@ export function getTokenExpiry(token: string): number | null {
   }
 }
 
-function msUntilExpiry(token: string): number {
+export function msUntilExpiry(token: string): number {
   const expiry = getTokenExpiry(token);
   if (expiry === null) return 0;
   return Math.max(0, expiry - Date.now());


### PR DESCRIPTION
## Summary
- enforce the @/ alias for deep relative imports
- update the analytics hook to use SWR-style loading/error handling
- add session-token helper coverage and a login-to-dashboard flow test

close #560
close #561
close #562
close #563